### PR TITLE
Fix read bug getting first item instead of specific item

### DIFF
--- a/aws-frauddetector-entitytype/src/aws_frauddetector_entitytype/handler_workers.py
+++ b/aws-frauddetector-entitytype/src/aws_frauddetector_entitytype/handler_workers.py
@@ -80,6 +80,8 @@ def execute_delete_entity_type_handler_work(session, model, progress):
 
 def execute_read_entity_type_handler_work(session, model, progress):
     afd_client = client_helpers.get_singleton_afd_client(session)
+    # read requests only include primary identifier (Arn). Extract Name from Arn
+    model.Name = model.Arn.split('/')[-1]
 
     # For contract_delete_read, we need to fail if the resource DNE
     # get entity_types will throw RNF Exception if entity_type DNE

--- a/aws-frauddetector-label/src/aws_frauddetector_label/handler_workers.py
+++ b/aws-frauddetector-label/src/aws_frauddetector_label/handler_workers.py
@@ -79,6 +79,8 @@ def execute_delete_label_handler_work(session, model, progress):
 
 def execute_read_label_handler_work(session, model, progress):
     afd_client = client_helpers.get_singleton_afd_client(session)
+    # read requests only include primary identifier (Arn). Extract Name from Arn
+    model.Name = model.Arn.split('/')[-1]
 
     # For contract_delete_read, we need to fail if the resource DNE
     # get labels will throw RNF Exception if label DNE

--- a/aws-frauddetector-outcome/src/aws_frauddetector_outcome/handler_workers.py
+++ b/aws-frauddetector-outcome/src/aws_frauddetector_outcome/handler_workers.py
@@ -79,6 +79,8 @@ def execute_delete_outcome_handler_work(session, model, progress):
 
 def execute_read_outcome_handler_work(session, model, progress):
     afd_client = client_helpers.get_singleton_afd_client(session)
+    # read requests only include primary identifier (Arn). Extract Name from Arn
+    model.Name = model.Arn.split('/')[-1]
 
     # For contract_delete_read, we need to fail if the resource DNE
     # get outcomes will throw RNF Exception if outcome DNE

--- a/aws-frauddetector-outcome/src/tests/handler_workers/test_read_handler_worker.py
+++ b/aws-frauddetector-outcome/src/tests/handler_workers/test_read_handler_worker.py
@@ -34,7 +34,7 @@ def test_execute_read_outcome_handler_work_outcome_dne_gets_not_found_error(monk
 
 
 def _setup_execute_read_outcome_handler_work_test(monkeypatch):
-    model = unit_test_utils.create_fake_model()
+    model = unit_test_utils.create_fake_model(is_output_model=True)
     progress = ProgressEvent(
         status=OperationStatus.IN_PROGRESS,
         resourceModel=model

--- a/aws-frauddetector-variable/src/aws_frauddetector_variable/handler_workers.py
+++ b/aws-frauddetector-variable/src/aws_frauddetector_variable/handler_workers.py
@@ -78,6 +78,8 @@ def execute_delete_variable_handler_work(session, model, progress):
 
 def execute_read_variable_handler_work(session, model, progress):
     afd_client = client_helpers.get_singleton_afd_client(session)
+    # read requests only include primary identifier (Arn). Extract Name from Arn
+    model.Name = model.Arn.split('/')[-1]
 
     # For contract_delete_read, we need to fail if the resource DNE
     # get variables will throw RNF Exception if variable DNE


### PR DESCRIPTION
### Problem

Read requests only send primary identifier (Arn) in the request, so when checking for existing resources, we were sending `None` as the `model.Name`. The api helpers remove None arguments silently, so this was just getting all resources and returning the first resource instead of getting a specific resource. I noticed this when comparing outputs obtained via reference vs. get attribute. We should have an integ test that confirms an output obtained by reference is the same as an output obtained by getting the attribute for the primary identifier.

### Changes

Extract Name from Arn as a quick fix. 

### Testing

`./run_unit_tests`
```
Required test coverage of 90.0% reached. Total coverage: 90.82%
==== 95 passed in 2.14s =====
```

`pre-commit run --all-files`
```
$ pre-commit run --all-files
Check for case conflicts.................................................Passed
Detect Private Key.......................................................Passed
Fix End of Files.........................................................Passed
Mixed line ending........................................................Passed
Trim Trailing Whitespace.................................................Passed
Pretty format JSON.......................................................Passed
Check for merge conflicts................................................Passed
Check Yaml...............................................................Passed
```


and `./cfn_server` + `cfn test` on all 4 affected RPs, all succeed, e.g.:
```
collected 16 items                                                                                                                                                                                                                                                           

handler_create.py::contract_create_delete PASSED                                                                                                                                                                                                                       [  6%]
handler_create.py::contract_invalid_create PASSED                                                                                                                                                                                                                      [ 12%]
handler_create.py::contract_create_duplicate SKIPPED (No writable identifiers. Skipping test.)                                                                                                                                                                         [ 18%]
handler_create.py::contract_create_read_success PASSED                                                                                                                                                                                                                 [ 25%]
handler_create.py::contract_create_list_success PASSED                                                                                                                                                                                                                 [ 31%]
handler_delete.py::contract_delete_read PASSED                                                                                                                                                                                                                         [ 37%]
handler_delete.py::contract_delete_list PASSED                                                                                                                                                                                                                         [ 43%]
handler_delete.py::contract_delete_update PASSED                                                                                                                                                                                                                       [ 50%]
handler_delete.py::contract_delete_delete PASSED                                                                                                                                                                                                                       [ 56%]
handler_delete.py::contract_delete_create SKIPPED (No writable identifiers. Skipping test.)                                                                                                                                                                            [ 62%]
handler_misc.py::contract_check_asserts_work PASSED                                                                                                                                                                                                                    [ 68%]
handler_read.py::contract_read_without_create PASSED                                                                                                                                                                                                                   [ 75%]
handler_update.py::contract_update_read_success PASSED                                                                                                                                                                                                                 [ 81%]
handler_update.py::contract_update_list_success PASSED                                                                                                                                                                                                                 [ 87%]
handler_update_invalid.py::contract_update_create_only_property PASSED                                                                                                                                                                                                 [ 93%]
handler_update_invalid.py::contract_update_non_existent_resource PASSED                                                                                                                                                                                                [100%]

==== 14 passed, 2 skipped in 165.18s (0:02:45) =
```

**Before**
![Read just gets first result from list, not exact match](https://user-images.githubusercontent.com/70152346/111675283-55ba2f80-87f3-11eb-9bec-fe0807b6ab60.png)

**After**
![Variable bug fixed](https://user-images.githubusercontent.com/70152346/111675310-5e126a80-87f3-11eb-90bd-4f6ef22651e0.png)

