### PR TITLE
implement delete worker helpers for detector

### DIFF
--- a/aws-frauddetector-detector/inputs/inputs_1_create.json
+++ b/aws-frauddetector-detector/inputs/inputs_1_create.json
@@ -34,6 +34,6 @@
   "EventType": {
     "Inline": false,
     "Name": "reference_event_type_for_detector",
-    "Arn": "arn:aws:frauddetector:us-west-2:123123123123:event_type/reference_event_type_for_detector"
+    "Arn": "arn:aws:frauddetector:us-west-2:123123123123:event-type/reference_event_type_for_detector"
   }
 }

--- a/aws-frauddetector-detector/inputs/inputs_1_invalid.json
+++ b/aws-frauddetector-detector/inputs/inputs_1_invalid.json
@@ -35,6 +35,6 @@
   "EventType": {
     "Inline": false,
     "Name": "reference_event_type_for_detector",
-    "Arn": "arn:aws:frauddetector:us-west-2:123123123123:event_type/reference_event_type_for_detector"
+    "Arn": "arn:aws:frauddetector:us-west-2:123123123123:event-type/reference_event_type_for_detector"
   }
 }

--- a/aws-frauddetector-detector/inputs/inputs_1_update.json
+++ b/aws-frauddetector-detector/inputs/inputs_1_update.json
@@ -42,6 +42,6 @@
   "EventType": {
     "Inline": false,
     "Name": "reference_event_type_for_detector",
-    "Arn": "arn:aws:frauddetector:us-west-2:123123123123:event_type/reference_event_type_for_detector"
+    "Arn": "arn:aws:frauddetector:us-west-2:123123123123:event-type/reference_event_type_for_detector"
   }
 }

--- a/aws-frauddetector-detector/src/aws_frauddetector_detector/helpers/api_helpers.py
+++ b/aws-frauddetector-detector/src/aws_frauddetector_detector/helpers/api_helpers.py
@@ -480,6 +480,26 @@ def call_delete_label(frauddetector_client, label_name: str):
     return frauddetector_client.delete_label(name=label_name)
 
 
+@api_call_with_debug_logs
+def call_delete_detector(frauddetector_client, detector_id: str):
+    return frauddetector_client.delete_detector(detectorId=detector_id)
+
+
+@api_call_with_debug_logs
+def call_delete_detector_version(frauddetector_client, detector_id: str, detector_version_id: str):
+    return frauddetector_client.delete_detector_version(detectorId=detector_id, detectorVersionId=detector_version_id)
+
+
+@api_call_with_debug_logs
+def call_delete_rule(frauddetector_client, detector_id: str, rule_id: str, rule_version: str):
+    rule = {
+        "detectorId": detector_id,
+        "ruleId": rule_id,
+        "ruleVersion": rule_version
+    }
+    return frauddetector_client.delete_rule(rule=rule)
+
+
 # Tagging
 
 

--- a/aws-frauddetector-detector/src/aws_frauddetector_detector/helpers/delete_worker_helpers.py
+++ b/aws-frauddetector-detector/src/aws_frauddetector_detector/helpers/delete_worker_helpers.py
@@ -1,15 +1,98 @@
 import logging
 
 from . import api_helpers, model_helpers
-from ..models import ResourceModel
+from .. import models
 
 # Use this logger to forward log messages to CloudWatch Logs.
 LOG = logging.getLogger(__name__)
 
 
-def delete_inline_dependencies(afd_client, model: ResourceModel):
-    inline_resources = model_helpers.get_inline_resources(event_type_model=model)
+ACTIVE_STATUS = 'ACTIVE'
+INACTIVE_STATUS = 'INACTIVE'
 
+
+def deactivate_and_delete_detector_versions_for_detector_model(afd_client, detector_model: models.ResourceModel):
+    describe_detector_response = api_helpers.call_describe_detector(frauddetector_client=afd_client,
+                                                                    detector_id=detector_model.DetectorId)
+    dv_summaries = describe_detector_response.get('detectorVersionSummaries', [])
+    for dv in dv_summaries:
+        if dv.get('status', '') == ACTIVE_STATUS:
+            api_helpers.call_update_detector_version_status(
+                frauddetector_client=afd_client,
+                detector_id=detector_model.DetectorId,
+                detector_version_id=dv.get('detectorVersionId', '-1'),
+                status=INACTIVE_STATUS
+            )
+        api_helpers.call_delete_detector_version(
+            frauddetector_client=afd_client,
+            detector_id=detector_model.DetectorId,
+            detector_version_id=dv.get('detectorVersionId', '-1')
+        )
+
+
+def delete_rules_and_inline_outcomes_for_detector_model(afd_client, detector_model: models.ResourceModel):
+    # get rules: id -> rules
+    get_rules_response = api_helpers.call_get_rules(
+        frauddetector_client=afd_client,
+        detector_id=detector_model.DetectorId
+    )
+    rule_details = get_rules_response.get('ruleDetails', [])
+    rule_models_by_rule_id_version = _create_rule_models_by_rule_id_rule_version_tuple(detector_model)
+    inline_outcome_names = set()
+    for rule_detail in rule_details:
+        rule_id = rule_detail.get('ruleId', '')
+        rule_version = rule_detail.get('ruleVersion', '-1')
+
+        # Check if rule is defined in CFN, and collect inline outcomes if so
+        rule_id_version_tuple = tuple([rule_id, rule_version])
+        if rule_id_version_tuple in rule_models_by_rule_id_version:
+            rule_model = rule_models_by_rule_id_version[rule_id_version_tuple]
+            inline_outcome_names.update([outcome.Name for outcome in rule_model.Outcomes if outcome.Inline])
+
+        # delete rule
+        api_helpers.call_delete_rule(
+            frauddetector_client=afd_client,
+            detector_id=detector_model.DetectorId,
+            rule_id=rule_id,
+            rule_version=rule_version
+        )
+
+    for outcome_name in inline_outcome_names:
+        api_helpers.call_delete_outcome(
+            frauddetector_client=afd_client,
+            outcome_name=outcome_name
+        )
+    return
+
+
+def delete_detector_for_detector_model(afd_client, detector_model: models.ResourceModel):
+    api_helpers.call_delete_detector(
+        frauddetector_client=afd_client,
+        detector_id=detector_model.DetectorId
+    )
+
+
+def delete_inline_dependencies_for_detector_model(afd_client, detector_model: models.ResourceModel):
+    if detector_model.EventType.Inline:
+        _delete_inline_dependencies_for_inline_event_type(afd_client, detector_model.EventType)
+        # delete event type
+        api_helpers.call_delete_event_type(
+            frauddetector_client=afd_client,
+            event_type_name=detector_model.EventType.Name
+        )
+
+
+def _create_rule_models_by_rule_id_rule_version_tuple(detector_model: models.ResourceModel):
+    dict_to_return = {}
+    if not detector_model.Rules:
+        return dict_to_return
+    for rule in detector_model.Rules:
+        dict_to_return[tuple([rule.RuleId, rule.RuleVersion])] = rule
+    return dict_to_return
+
+
+def _delete_inline_dependencies_for_inline_event_type(afd_client, event_type_model: models.EventType):
+    inline_resources = model_helpers.get_inline_resources_for_event_type(event_type_model=event_type_model)
     _delete_inline_event_variables(afd_client, inline_resources['event_variables'])
     _delete_inline_entity_types(afd_client, inline_resources['entity_types'])
     _delete_inline_labels(afd_client, inline_resources['labels'])

--- a/aws-frauddetector-detector/src/aws_frauddetector_detector/helpers/model_helpers.py
+++ b/aws-frauddetector-detector/src/aws_frauddetector_detector/helpers/model_helpers.py
@@ -101,12 +101,12 @@ def get_model_for_detector(frauddetector_client, detector, model: models.Resourc
                                                         rule_id,
                                                         rule_version,
                                                         referenced_outcome_names)
-        model.Rules.append(rule_to_append)
+        model_to_return.Rules.append(rule_to_append)
 
     # get tags
     detector_tags = _get_tags_for_given_arn(frauddetector_client, detector_arn)
     # TODO: reorder tags to the same order as the input model to work around contract test bug?
-    model.Tags = get_tag_models_from_tags(detector_tags)
+    model_to_return.Tags = get_tag_models_from_tags(detector_tags)
 
     return model_to_return
 


### PR DESCRIPTION
also fix some bugs


*Description of changes:*

Add delete worker helpers

### Testing
Still need to add some unit tests, but I have been using contract tests as my source of confidence in this code. 

contract tests for create/read/delete all pass:
```
handler_create.py::contract_create_read_success <- ../../../cfn-cli/cloudformation-cli/src/rpdk/core/contract/suite/handler_create.py PASSED
handler_create.py::contract_create_delete <- ../../../cfn-cli/cloudformation-cli/src/rpdk/core/contract/suite/handler_create.py PASSED
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
