### PR TITLE
update generated README for eventtype

### DIFF
--- a/aws-frauddetector-eventtype/docs/README.md
+++ b/aws-frauddetector-eventtype/docs/README.md
@@ -91,7 +91,7 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 #### Labels
 
-_Required_: No
+_Required_: Yes
 
 _Type_: List of <a href="label.md">Label</a>
 


### PR DESCRIPTION
*Description of changes:*

Ran `cfn generate` for all resource providers, looks like the generated README change for eventtype hasn't been picked up yet. This updates the documentation for EventType to list labels as required. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
