### PR TITLE
add missing delete DV permissions to detector resource role

### DIFF
--- a/aws-frauddetector-detector/resource-role.yaml
+++ b/aws-frauddetector-detector/resource-role.yaml
@@ -27,6 +27,7 @@ Resources:
                 - "frauddetector:CreateRule"
                 - "frauddetector:CreateVariable"
                 - "frauddetector:DeleteDetector"
+                - "frauddetector:DeleteDetectorVersion"
                 - "frauddetector:DeleteEntityType"
                 - "frauddetector:DeleteEventType"
                 - "frauddetector:DeleteLabel"


### PR DESCRIPTION
*Description of changes:*

DeleteDetectorVersion permissions were missing from resource role.

*Testing*
`./run_unit_tests`, `pre-commit run --all-files`. Called create/delete stack with test role with the same permissions, Delete DV worked. 

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
