### PR TITLE
Develop consistency for Detector

### DIFF
--- a/aws-frauddetector-detector/aws-frauddetector-detector.json
+++ b/aws-frauddetector-detector/aws-frauddetector-detector.json
@@ -541,6 +541,7 @@
         "frauddetector:GetOutcomes",
         "frauddetector:GetEntityTypes",
         "frauddetector:DeleteDetector",
+        "frauddetector:DeleteDetectorVersion",
         "frauddetector:DeleteRule",
         "frauddetector:DeleteEventType",
         "frauddetector:DeleteVariable",

--- a/aws-frauddetector-detector/src/aws_frauddetector_detector/helpers/api_helpers.py
+++ b/aws-frauddetector-detector/src/aws_frauddetector_detector/helpers/api_helpers.py
@@ -3,6 +3,7 @@ from . import validation_helpers
 
 import functools
 import logging
+import time
 
 # Use this logger to forward log messages to CloudWatch Logs.
 LOG = logging.getLogger(__name__)
@@ -11,6 +12,9 @@ LOG.setLevel(level=logging.INFO)
 # Maximum number of pages to get for paginated calls
 # for page size of 100, 100 pages is 10,000 resources, which is twice the largest default service limit
 MAXIMUM_NUMBER_OF_PAGES = 100
+
+# Number of seconds to wait for eventually consistency for `retry_not_found_exceptions` decorator
+CONSISTENCY_SLEEP_TIME = 1.0
 
 
 # Wrapper/decorator
@@ -27,6 +31,32 @@ def api_call_with_debug_logs(func):
         LOG.debug(f'Finished function {func.__name__!r}, returning {value}')
         return value
     return log_wrapper
+
+
+def retry_not_found_exceptions(func):
+    """
+    Retries boto3 not found exception for the decorated function.
+    """
+    @functools.wraps(func)
+    def retry_not_found_exceptions_wrapper(*args, **kwargs):
+        afd_client = kwargs.get('frauddetector_client', None)
+        if not afd_client:
+            if len(args) > 0:
+                afd_client = args[0]
+            else:
+                # We can't grab afd_client, so we can't compare to AFD's RNF Exception.
+                # Just run the function, rather than throwing an error
+                LOG.error('retry_not_found_exceptions_wrapper could not find the afd client! '
+                          'Perhaps the decorator was added to a method that is not supported?')
+                return func(*args, **kwargs)
+        try:
+            return func(*args, **kwargs)
+        except afd_client.exceptions.ResourceNotFoundException:
+            LOG.warning(f'caught a resource not found exception.'
+                        f' sleeping {CONSISTENCY_SLEEP_TIME} seconds and retrying api call for consistency...')
+            time.sleep(CONSISTENCY_SLEEP_TIME)
+            return func(*args, **kwargs)
+    return retry_not_found_exceptions_wrapper
 
 
 def paginated_api_call(item_to_collect, criteria_to_keep=lambda x, y: True, max_pages=MAXIMUM_NUMBER_OF_PAGES):
@@ -237,6 +267,7 @@ def call_create_rule(frauddetector_client,
     return frauddetector_client.create_rule(**args)
 
 
+@retry_not_found_exceptions
 @api_call_with_debug_logs
 def call_create_detector_version(frauddetector_client,
                                  detector_id: str,
@@ -262,6 +293,7 @@ def call_create_detector_version(frauddetector_client,
 # Update APIs
 
 
+@retry_not_found_exceptions
 @api_call_with_debug_logs
 def call_update_variable(frauddetector_client,
                          variable_name: str,
@@ -288,6 +320,7 @@ def call_update_variable(frauddetector_client,
     return frauddetector_client.update_variable(**args)
 
 
+@retry_not_found_exceptions
 @api_call_with_debug_logs
 def call_update_rule_version(frauddetector_client,
                              detector_id: str,
@@ -319,6 +352,7 @@ def call_update_rule_version(frauddetector_client,
     return frauddetector_client.update_rule_version(**args)
 
 
+@retry_not_found_exceptions
 @api_call_with_debug_logs
 def call_update_detector_version(frauddetector_client,
                                  detector_id: str,
@@ -341,6 +375,7 @@ def call_update_detector_version(frauddetector_client,
     return frauddetector_client.update_detector_version(**args)
 
 
+@retry_not_found_exceptions
 @api_call_with_debug_logs
 def call_update_detector_version_status(frauddetector_client,
                                         detector_id: str,
@@ -366,6 +401,7 @@ def call_update_detector_version_status(frauddetector_client,
 # Describe APIs
 
 
+@retry_not_found_exceptions
 @paginated_api_call(item_to_collect='detectorVersionSummaries')
 @api_call_with_debug_logs
 def call_describe_detector(frauddetector_client, detector_id):
@@ -383,7 +419,7 @@ def call_describe_detector(frauddetector_client, detector_id):
 
 # Get APIs
 
-
+@retry_not_found_exceptions
 @api_call_with_debug_logs
 def call_get_detector_version(frauddetector_client, detector_id: str, detector_version_id: str):
     """
@@ -400,6 +436,7 @@ def call_get_detector_version(frauddetector_client, detector_id: str, detector_v
     return frauddetector_client.get_detector_version(**args)
 
 
+@retry_not_found_exceptions
 @paginated_api_call(item_to_collect='detectors')
 @api_call_with_debug_logs
 def call_get_detectors(frauddetector_client, detector_id: str = None):
@@ -416,6 +453,7 @@ def call_get_detectors(frauddetector_client, detector_id: str = None):
     return frauddetector_client.get_detectors(**args)
 
 
+@retry_not_found_exceptions
 @paginated_api_call(item_to_collect='ruleDetails')
 @api_call_with_debug_logs
 def call_get_rules(frauddetector_client, detector_id: str, rule_id: str = None, rule_version: str = None):
@@ -437,6 +475,7 @@ def call_get_rules(frauddetector_client, detector_id: str, rule_id: str = None, 
     return frauddetector_client.get_rules(**args)
 
 
+@retry_not_found_exceptions
 @paginated_api_call(item_to_collect='outcomes')
 @api_call_with_debug_logs
 def call_get_outcomes(frauddetector_client, outcome_name: str = None):
@@ -453,6 +492,7 @@ def call_get_outcomes(frauddetector_client, outcome_name: str = None):
     return frauddetector_client.get_outcomes(**args)
 
 
+@retry_not_found_exceptions
 @paginated_api_call(item_to_collect='variables')
 @api_call_with_debug_logs
 def call_get_variables(frauddetector_client, variable_name: str = None):
@@ -469,6 +509,7 @@ def call_get_variables(frauddetector_client, variable_name: str = None):
     return frauddetector_client.get_variables(**args)
 
 
+@retry_not_found_exceptions
 @paginated_api_call(item_to_collect='labels')
 @api_call_with_debug_logs
 def call_get_labels(frauddetector_client, label_name: str = None):
@@ -479,6 +520,7 @@ def call_get_labels(frauddetector_client, label_name: str = None):
     return frauddetector_client.get_labels(**args)
 
 
+@retry_not_found_exceptions
 @paginated_api_call(item_to_collect='entityTypes')
 @api_call_with_debug_logs
 def call_get_entity_types(frauddetector_client, entity_type_name: str = None):
@@ -489,6 +531,7 @@ def call_get_entity_types(frauddetector_client, entity_type_name: str = None):
     return frauddetector_client.get_entity_types(**args)
 
 
+@retry_not_found_exceptions
 @paginated_api_call(item_to_collect='eventTypes')
 @api_call_with_debug_logs
 def call_get_event_types(frauddetector_client, event_type_name: str = None):
@@ -556,6 +599,7 @@ def call_delete_rule(frauddetector_client, detector_id: str, rule_id: str, rule_
 # Tagging
 
 
+@retry_not_found_exceptions
 @paginated_api_call(item_to_collect='tags')
 @api_call_with_debug_logs
 def call_list_tags_for_resource(frauddetector_client, resource_arn: str):
@@ -568,6 +612,7 @@ def call_list_tags_for_resource(frauddetector_client, resource_arn: str):
     return frauddetector_client.list_tags_for_resource(resourceARN=resource_arn)
 
 
+@retry_not_found_exceptions
 @api_call_with_debug_logs
 def call_tag_resource(frauddetector_client, resource_arn: str, tags: List[dict]):
     """
@@ -580,6 +625,7 @@ def call_tag_resource(frauddetector_client, resource_arn: str, tags: List[dict])
     return frauddetector_client.tag_resource(resourceARN=resource_arn, tags=tags)
 
 
+@retry_not_found_exceptions
 @api_call_with_debug_logs
 def call_untag_resource(frauddetector_client, resource_arn: str, tag_keys: List[str]):
     """

--- a/aws-frauddetector-detector/src/aws_frauddetector_detector/helpers/client_helpers.py
+++ b/aws-frauddetector-detector/src/aws_frauddetector_detector/helpers/client_helpers.py
@@ -1,10 +1,20 @@
+from botocore.config import Config
 from cloudformation_cli_python_lib import (
     SessionProxy,
     exceptions,
 )
 
 
+BOTO3_CLIENT_CONFIG_WITH_STANDARD_RETRIES = Config(
+    retries={
+        'total_max_attempts': 3,
+        'mode': 'standard'
+    }
+)
+
+
 def get_afd_client(session):
     if isinstance(session, SessionProxy):
-        return session.client("frauddetector")
+        return session.client(service_name="frauddetector",
+                              config=BOTO3_CLIENT_CONFIG_WITH_STANDARD_RETRIES)
     raise exceptions.InternalFailure(f"Error: failed to get frauddetector client.")

--- a/aws-frauddetector-detector/src/aws_frauddetector_detector/tests/helpers/test_api_helpers.py
+++ b/aws-frauddetector-detector/src/aws_frauddetector_detector/tests/helpers/test_api_helpers.py
@@ -4,9 +4,71 @@ from ...helpers import (
 )
 from .. import unit_test_utils
 from unittest.mock import MagicMock
+from botocore.exceptions import ClientError
 
 NUMBER_OF_ITEMS_PER_PAGE = 2
 MAX_PAGES = 10
+
+
+def test_retry_not_found_exceptions_decorator_happy_case():
+    mock_afd_client = unit_test_utils.create_mock_afd_client()
+    mock_afd_client.get_labels = MagicMock()
+    mock_afd_client.exceptions.ResourceNotFoundException = ClientError
+    mock_afd_client.get_labels.side_effect = [
+        ClientError({'Code': '', 'Message': ''}, 'get_labels'),
+        {
+            'labels': [{'property': f'{j}'} for j in range(NUMBER_OF_ITEMS_PER_PAGE)]
+        }
+    ]
+
+    @api_helpers.retry_not_found_exceptions
+    def call_get_labels(frauddetector_client):
+        return frauddetector_client.get_labels()
+
+    response = call_get_labels(mock_afd_client)
+    assert len(response['labels']) == NUMBER_OF_ITEMS_PER_PAGE
+    assert mock_afd_client.get_labels.call_count == 2
+
+
+def test_retry_not_found_exceptions_decorator_no_exception():
+    mock_afd_client = unit_test_utils.create_mock_afd_client()
+    mock_afd_client.get_labels = MagicMock(return_value={
+        'labels': [{'property': f'{j}'} for j in range(NUMBER_OF_ITEMS_PER_PAGE)]
+    })
+
+    @api_helpers.retry_not_found_exceptions
+    def call_get_labels(frauddetector_client):
+        return frauddetector_client.get_labels()
+
+    response = call_get_labels(mock_afd_client)
+    assert len(response['labels']) == NUMBER_OF_ITEMS_PER_PAGE
+    assert mock_afd_client.get_labels.call_count == 1
+
+
+def test_retry_not_found_exceptions_decorator_multi_page():
+    mock_afd_client = unit_test_utils.create_mock_afd_client()
+    mock_afd_client.get_labels = MagicMock()
+    mock_afd_client.exceptions.ResourceNotFoundException = ClientError
+    side_effects = [
+        ClientError({'Code': '', 'Message': ''}, 'get_labels')
+    ]
+    side_effects.extend([
+        {
+            'nextToken': 'notNone',
+            'labels': [{'property': f'{i}.{j}'} for j in range(NUMBER_OF_ITEMS_PER_PAGE)]
+        } for i in range(MAX_PAGES + 10)
+    ])
+    mock_afd_client.get_labels.side_effect = side_effects
+
+    @api_helpers.retry_not_found_exceptions
+    @api_helpers.paginated_api_call('labels', max_pages=MAX_PAGES)
+    @api_helpers.api_call_with_debug_logs
+    def call_get_labels(frauddetector_client, nextToken=None):
+        return frauddetector_client.get_labels(nextToken)
+
+    response = call_get_labels(mock_afd_client)
+    assert len(response['labels']) == NUMBER_OF_ITEMS_PER_PAGE * MAX_PAGES
+    assert mock_afd_client.get_labels.call_count == MAX_PAGES + 1
 
 
 def test_paginated_api_call_not_infinite_loop():

--- a/aws-frauddetector-detector/src/aws_frauddetector_detector/tests/helpers/test_validation_helpers.py
+++ b/aws-frauddetector-detector/src/aws_frauddetector_detector/tests/helpers/test_validation_helpers.py
@@ -9,7 +9,9 @@ def test_check_if_get_labels_succeeds_client_error_returns_false():
     mock_afd_client = unit_test_utils.create_mock_afd_client()
     mock_afd_client.get_labels = MagicMock()
     mock_afd_client.exceptions.ResourceNotFoundException = ClientError
-    mock_afd_client.get_labels.side_effect = [ClientError({'Code': '', 'Message': ''}, 'get_labels')]
+    # We retry NotFound (for consistency), so return not found twice
+    mock_afd_client.get_labels.side_effect = [ClientError({'Code': '', 'Message': ''}, 'get_labels'),
+                                              ClientError({'Code': '', 'Message': ''}, 'get_labels')]
 
     # Act
     result = validation_helpers.check_if_get_labels_succeeds(mock_afd_client, unit_test_utils.FAKE_NAME)
@@ -41,7 +43,9 @@ def test_check_if_get_entity_types_succeeds_client_error_returns_false():
     mock_afd_client = unit_test_utils.create_mock_afd_client()
     mock_afd_client.get_entity_types = MagicMock()
     mock_afd_client.exceptions.ResourceNotFoundException = ClientError
-    mock_afd_client.get_entity_types.side_effect = [ClientError({'Code': '', 'Message': ''}, 'get_entity_types')]
+    # We retry NotFound (for consistency), so return not found twice
+    mock_afd_client.get_entity_types.side_effect = [ClientError({'Code': '', 'Message': ''}, 'get_entity_types'),
+                                                    ClientError({'Code': '', 'Message': ''}, 'get_entity_types')]
 
     # Act
     result = validation_helpers.check_if_get_entity_types_succeeds(mock_afd_client, unit_test_utils.FAKE_NAME)
@@ -73,7 +77,9 @@ def test_check_if_get_variables_succeeds_client_error_returns_false():
     mock_afd_client = unit_test_utils.create_mock_afd_client()
     mock_afd_client.get_variables = MagicMock()
     mock_afd_client.exceptions.ResourceNotFoundException = ClientError
-    mock_afd_client.get_variables.side_effect = [ClientError({'Code': '', 'Message': ''}, 'get_variables')]
+    # We retry NotFound (for consistency), so return not found twice
+    mock_afd_client.get_variables.side_effect = [ClientError({'Code': '', 'Message': ''}, 'get_variables'),
+                                                 ClientError({'Code': '', 'Message': ''}, 'get_variables')]
 
     # Act
     result = validation_helpers.check_if_get_variables_succeeds(mock_afd_client, unit_test_utils.FAKE_NAME)
@@ -105,7 +111,9 @@ def test_check_if_get_event_types_succeeds_client_error_returns_false():
     mock_afd_client = unit_test_utils.create_mock_afd_client()
     mock_afd_client.get_event_types = MagicMock()
     mock_afd_client.exceptions.ResourceNotFoundException = ClientError
-    mock_afd_client.get_event_types.side_effect = [ClientError({'Code': '', 'Message': ''}, 'get_event_types')]
+    # We retry NotFound (for consistency), so return not found twice
+    mock_afd_client.get_event_types.side_effect = [ClientError({'Code': '', 'Message': ''}, 'get_event_types'),
+                                                   ClientError({'Code': '', 'Message': ''}, 'get_event_types')]
 
     # Act
     result = validation_helpers.check_if_get_event_types_succeeds(mock_afd_client, unit_test_utils.FAKE_NAME)

--- a/aws-frauddetector-entitytype/src/aws_frauddetector_entitytype/helpers/client_helpers.py
+++ b/aws-frauddetector-entitytype/src/aws_frauddetector_entitytype/helpers/client_helpers.py
@@ -1,10 +1,20 @@
+from botocore.config import Config
 from cloudformation_cli_python_lib import (
     SessionProxy,
     exceptions,
 )
 
 
+BOTO3_CLIENT_CONFIG_WITH_STANDARD_RETRIES = Config(
+    retries={
+        'total_max_attempts': 3,
+        'mode': 'standard'
+    }
+)
+
+
 def get_afd_client(session):
     if isinstance(session, SessionProxy):
-        return session.client("frauddetector")
+        return session.client(service_name="frauddetector",
+                              config=BOTO3_CLIENT_CONFIG_WITH_STANDARD_RETRIES)
     raise exceptions.InternalFailure(f"Error: failed to get frauddetector client.")

--- a/aws-frauddetector-eventtype/src/aws_frauddetector_eventtype/helpers/client_helpers.py
+++ b/aws-frauddetector-eventtype/src/aws_frauddetector_eventtype/helpers/client_helpers.py
@@ -1,10 +1,20 @@
+from botocore.config import Config
 from cloudformation_cli_python_lib import (
     SessionProxy,
     exceptions,
 )
 
 
+BOTO3_CLIENT_CONFIG_WITH_STANDARD_RETRIES = Config(
+    retries={
+        'total_max_attempts': 3,
+        'mode': 'standard'
+    }
+)
+
+
 def get_afd_client(session):
     if isinstance(session, SessionProxy):
-        return session.client("frauddetector")
+        return session.client(service_name="frauddetector",
+                              config=BOTO3_CLIENT_CONFIG_WITH_STANDARD_RETRIES)
     raise exceptions.InternalFailure(f"Error: failed to get frauddetector client.")

--- a/aws-frauddetector-label/src/aws_frauddetector_label/helpers/client_helpers.py
+++ b/aws-frauddetector-label/src/aws_frauddetector_label/helpers/client_helpers.py
@@ -1,11 +1,20 @@
+from botocore.config import Config
 from cloudformation_cli_python_lib import (
     SessionProxy,
     exceptions,
 )
 
 
+BOTO3_CLIENT_CONFIG_WITH_STANDARD_RETRIES = Config(
+    retries={
+        'total_max_attempts': 3,
+        'mode': 'standard'
+    }
+)
+
+
 def get_afd_client(session):
     if isinstance(session, SessionProxy):
-        return session.client("frauddetector")
-
+        return session.client(service_name="frauddetector",
+                              config=BOTO3_CLIENT_CONFIG_WITH_STANDARD_RETRIES)
     raise exceptions.InternalFailure(f"Error: failed to get frauddetector client.")

--- a/aws-frauddetector-outcome/src/aws_frauddetector_outcome/helpers/client_helpers.py
+++ b/aws-frauddetector-outcome/src/aws_frauddetector_outcome/helpers/client_helpers.py
@@ -1,11 +1,20 @@
+from botocore.config import Config
 from cloudformation_cli_python_lib import (
     SessionProxy,
     exceptions,
 )
 
 
+BOTO3_CLIENT_CONFIG_WITH_STANDARD_RETRIES = Config(
+    retries={
+        'total_max_attempts': 3,
+        'mode': 'standard'
+    }
+)
+
+
 def get_afd_client(session):
     if isinstance(session, SessionProxy):
-        return session.client("frauddetector")
-
+        return session.client(service_name="frauddetector",
+                              config=BOTO3_CLIENT_CONFIG_WITH_STANDARD_RETRIES)
     raise exceptions.InternalFailure(f"Error: failed to get frauddetector client.")


### PR DESCRIPTION
### Force Push Revision 1:
Added retry on RNF decorator to other APIs that can throw ResourceNotFoundException.

### Description of changes

This adds a decorator that retries ResourceNotFoundException after sleeping for 1 second, and applies the decorator to AFD get* and describe* calls. This has only been added to Detector for now, but if approved, I will create a subsequent commit that makes the same changes for the other RPs. (I want to avoid churn, since we still have not consolidated common code across RPs).

Also, add a missing permission from detector JSON, and add standard retry config to boto3 client for all RPs (default is legacy retry config). 

### Testing
`./run_unit_tests`, and `./cfn_server detector`+`cfn test`, everything is green. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
