### PR TITLE
add retry_not_found_exceptions to other RPs

### DIFF
--- a/aws-frauddetector-entitytype/src/aws_frauddetector_entitytype/helpers/api_helpers.py
+++ b/aws-frauddetector-entitytype/src/aws_frauddetector_entitytype/helpers/api_helpers.py
@@ -3,6 +3,7 @@ from . import validation_helpers
 
 import functools
 import logging
+import time
 
 # Use this logger to forward log messages to CloudWatch Logs.
 LOG = logging.getLogger(__name__)
@@ -11,6 +12,9 @@ LOG.setLevel(logging.DEBUG)
 # Maximum number of pages to get for paginated calls
 # for page size of 100, 100 pages is 10,000 resources, which is twice the largest default service limit
 MAXIMUM_NUMBER_OF_PAGES = 100
+
+# Number of seconds to wait for eventually consistency for `retry_not_found_exceptions` decorator
+CONSISTENCY_SLEEP_TIME = 1.0
 
 
 # Wrapper/decorator
@@ -27,6 +31,32 @@ def api_call_with_debug_logs(func):
         LOG.debug(f'Finished function {func.__name__!r}, returning {value}')
         return value
     return log_wrapper
+
+
+def retry_not_found_exceptions(func):
+    """
+    Retries boto3 not found exception for the decorated function.
+    """
+    @functools.wraps(func)
+    def retry_not_found_exceptions_wrapper(*args, **kwargs):
+        afd_client = kwargs.get('frauddetector_client', None)
+        if not afd_client:
+            if len(args) > 0:
+                afd_client = args[0]
+            else:
+                # We can't grab afd_client, so we can't compare to AFD's RNF Exception.
+                # Just run the function, rather than throwing an error
+                LOG.error('retry_not_found_exceptions_wrapper could not find the afd client! '
+                          'Perhaps the decorator was added to a method that is not supported?')
+                return func(*args, **kwargs)
+        try:
+            return func(*args, **kwargs)
+        except afd_client.exceptions.ResourceNotFoundException:
+            LOG.warning(f'caught a resource not found exception.'
+                        f' sleeping {CONSISTENCY_SLEEP_TIME} seconds and retrying api call for consistency...')
+            time.sleep(CONSISTENCY_SLEEP_TIME)
+            return func(*args, **kwargs)
+    return retry_not_found_exceptions_wrapper
 
 
 def paginated_api_call(item_to_collect, criteria_to_keep=lambda x, y: True, max_pages=MAXIMUM_NUMBER_OF_PAGES):
@@ -235,8 +265,7 @@ def call_batch_create_variable(frauddetector_client,
     return frauddetector_client.batch_create_variable(**args)
 
 # Update APIs
-
-
+@retry_not_found_exceptions
 @api_call_with_debug_logs
 def call_update_variable(frauddetector_client,
                          variable_name: str,
@@ -263,6 +292,7 @@ def call_update_variable(frauddetector_client,
 # Get APIs
 
 
+@retry_not_found_exceptions
 @paginated_api_call(item_to_collect='outcomes')
 @api_call_with_debug_logs
 def call_get_outcomes(frauddetector_client, outcome_name: str = None):
@@ -279,6 +309,7 @@ def call_get_outcomes(frauddetector_client, outcome_name: str = None):
     return frauddetector_client.get_outcomes(**args)
 
 
+@retry_not_found_exceptions
 @paginated_api_call(item_to_collect='variables')
 @api_call_with_debug_logs
 def call_get_variables(frauddetector_client, variable_name: str = None):
@@ -295,6 +326,7 @@ def call_get_variables(frauddetector_client, variable_name: str = None):
     return frauddetector_client.get_variables(**args)
 
 
+@retry_not_found_exceptions
 @paginated_api_call(item_to_collect='detectors')
 @api_call_with_debug_logs
 def call_get_detectors(frauddetector_client, detector_id: str = None):
@@ -305,6 +337,7 @@ def call_get_detectors(frauddetector_client, detector_id: str = None):
     return frauddetector_client.get_detectors(**args)
 
 
+@retry_not_found_exceptions
 @paginated_api_call(item_to_collect='labels')
 @api_call_with_debug_logs
 def call_get_labels(frauddetector_client, label_name: str = None):
@@ -315,6 +348,7 @@ def call_get_labels(frauddetector_client, label_name: str = None):
     return frauddetector_client.get_labels(**args)
 
 
+@retry_not_found_exceptions
 @paginated_api_call(item_to_collect='entityTypes')
 @api_call_with_debug_logs
 def call_get_entity_types(frauddetector_client, entity_type_name: str = None):
@@ -325,6 +359,7 @@ def call_get_entity_types(frauddetector_client, entity_type_name: str = None):
     return frauddetector_client.get_entity_types(**args)
 
 
+@retry_not_found_exceptions
 @paginated_api_call(item_to_collect='eventTypes')
 @api_call_with_debug_logs
 def call_get_event_types(frauddetector_client, event_type_name: str = None):
@@ -380,8 +415,7 @@ def call_delete_label(frauddetector_client, label_name: str):
 
 
 # Tagging
-
-
+@retry_not_found_exceptions
 @paginated_api_call(item_to_collect='tags')
 @api_call_with_debug_logs
 def call_list_tags_for_resource(frauddetector_client, resource_arn: str):
@@ -392,8 +426,7 @@ def call_list_tags_for_resource(frauddetector_client, resource_arn: str):
     :return: result has an exhaustive list of tags attached to the resource
     """
     return frauddetector_client.list_tags_for_resource(resourceARN=resource_arn)
-
-
+@retry_not_found_exceptions
 @api_call_with_debug_logs
 def call_tag_resource(frauddetector_client, resource_arn: str, tags: List[dict]):
     """
@@ -404,8 +437,7 @@ def call_tag_resource(frauddetector_client, resource_arn: str, tags: List[dict])
     :return: success will return a 200 with no body
     """
     return frauddetector_client.tag_resource(resourceARN=resource_arn, tags=tags)
-
-
+@retry_not_found_exceptions
 @api_call_with_debug_logs
 def call_untag_resource(frauddetector_client, resource_arn: str, tag_keys: List[str]):
     """

--- a/aws-frauddetector-entitytype/src/aws_frauddetector_entitytype/tests/helpers/test_api_helpers.py
+++ b/aws-frauddetector-entitytype/src/aws_frauddetector_entitytype/tests/helpers/test_api_helpers.py
@@ -4,9 +4,71 @@ from ...helpers import (
 )
 from .. import unit_test_utils
 from unittest.mock import MagicMock
+from botocore.exceptions import ClientError
 
 NUMBER_OF_ITEMS_PER_PAGE = 2
 MAX_PAGES = 10
+
+
+def test_retry_not_found_exceptions_decorator_happy_case():
+    mock_afd_client = unit_test_utils.create_mock_afd_client()
+    mock_afd_client.get_labels = MagicMock()
+    mock_afd_client.exceptions.ResourceNotFoundException = ClientError
+    mock_afd_client.get_labels.side_effect = [
+        ClientError({'Code': '', 'Message': ''}, 'get_labels'),
+        {
+            'labels': [{'property': f'{j}'} for j in range(NUMBER_OF_ITEMS_PER_PAGE)]
+        }
+    ]
+
+    @api_helpers.retry_not_found_exceptions
+    def call_get_labels(frauddetector_client):
+        return frauddetector_client.get_labels()
+
+    response = call_get_labels(mock_afd_client)
+    assert len(response['labels']) == NUMBER_OF_ITEMS_PER_PAGE
+    assert mock_afd_client.get_labels.call_count == 2
+
+
+def test_retry_not_found_exceptions_decorator_no_exception():
+    mock_afd_client = unit_test_utils.create_mock_afd_client()
+    mock_afd_client.get_labels = MagicMock(return_value={
+        'labels': [{'property': f'{j}'} for j in range(NUMBER_OF_ITEMS_PER_PAGE)]
+    })
+
+    @api_helpers.retry_not_found_exceptions
+    def call_get_labels(frauddetector_client):
+        return frauddetector_client.get_labels()
+
+    response = call_get_labels(mock_afd_client)
+    assert len(response['labels']) == NUMBER_OF_ITEMS_PER_PAGE
+    assert mock_afd_client.get_labels.call_count == 1
+
+
+def test_retry_not_found_exceptions_decorator_multi_page():
+    mock_afd_client = unit_test_utils.create_mock_afd_client()
+    mock_afd_client.get_labels = MagicMock()
+    mock_afd_client.exceptions.ResourceNotFoundException = ClientError
+    side_effects = [
+        ClientError({'Code': '', 'Message': ''}, 'get_labels')
+    ]
+    side_effects.extend([
+        {
+            'nextToken': 'notNone',
+            'labels': [{'property': f'{i}.{j}'} for j in range(NUMBER_OF_ITEMS_PER_PAGE)]
+        } for i in range(MAX_PAGES + 10)
+    ])
+    mock_afd_client.get_labels.side_effect = side_effects
+
+    @api_helpers.retry_not_found_exceptions
+    @api_helpers.paginated_api_call('labels', max_pages=MAX_PAGES)
+    @api_helpers.api_call_with_debug_logs
+    def call_get_labels(frauddetector_client, nextToken=None):
+        return frauddetector_client.get_labels(nextToken)
+
+    response = call_get_labels(mock_afd_client)
+    assert len(response['labels']) == NUMBER_OF_ITEMS_PER_PAGE * MAX_PAGES
+    assert mock_afd_client.get_labels.call_count == MAX_PAGES + 1
 
 
 def test_paginated_api_call_not_infinite_loop():

--- a/aws-frauddetector-entitytype/src/aws_frauddetector_entitytype/tests/helpers/test_validation_helpers.py
+++ b/aws-frauddetector-entitytype/src/aws_frauddetector_entitytype/tests/helpers/test_validation_helpers.py
@@ -9,7 +9,9 @@ def test_check_if_get_entity_types_succeeds_client_error_returns_false():
     mock_afd_client = unit_test_utils.create_mock_afd_client()
     mock_afd_client.get_entity_types = MagicMock()
     mock_afd_client.exceptions.ResourceNotFoundException = ClientError
-    mock_afd_client.get_entity_types.side_effect = [ClientError({'Code': '', 'Message': ''}, 'get_entity_types')]
+    # We retry NotFound (for consistency), so return not found twice
+    mock_afd_client.get_entity_types.side_effect = [ClientError({'Code': '', 'Message': ''}, 'get_entity_types'),
+                                                    ClientError({'Code': '', 'Message': ''}, 'get_entity_types')]
 
     # Act
     result = validation_helpers.check_if_get_entity_types_succeeds(mock_afd_client, unit_test_utils.FAKE_NAME)

--- a/aws-frauddetector-eventtype/src/aws_frauddetector_eventtype/helpers/api_helpers.py
+++ b/aws-frauddetector-eventtype/src/aws_frauddetector_eventtype/helpers/api_helpers.py
@@ -3,6 +3,7 @@ from . import validation_helpers
 
 import functools
 import logging
+import time
 
 # Use this logger to forward log messages to CloudWatch Logs.
 LOG = logging.getLogger(__name__)
@@ -11,6 +12,9 @@ LOG.setLevel(level=logging.INFO)
 # Maximum number of pages to get for paginated calls
 # for page size of 100, 100 pages is 10,000 resources, which is twice the largest default service limit
 MAXIMUM_NUMBER_OF_PAGES = 100
+
+# Number of seconds to wait for eventually consistency for `retry_not_found_exceptions` decorator
+CONSISTENCY_SLEEP_TIME = 1.0
 
 
 # Wrapper/decorator
@@ -27,6 +31,32 @@ def api_call_with_debug_logs(func):
         LOG.debug(f'Finished function {func.__name__!r}, returning {value}')
         return value
     return log_wrapper
+
+
+def retry_not_found_exceptions(func):
+    """
+    Retries boto3 not found exception for the decorated function.
+    """
+    @functools.wraps(func)
+    def retry_not_found_exceptions_wrapper(*args, **kwargs):
+        afd_client = kwargs.get('frauddetector_client', None)
+        if not afd_client:
+            if len(args) > 0:
+                afd_client = args[0]
+            else:
+                # We can't grab afd_client, so we can't compare to AFD's RNF Exception.
+                # Just run the function, rather than throwing an error
+                LOG.error('retry_not_found_exceptions_wrapper could not find the afd client! '
+                          'Perhaps the decorator was added to a method that is not supported?')
+                return func(*args, **kwargs)
+        try:
+            return func(*args, **kwargs)
+        except afd_client.exceptions.ResourceNotFoundException:
+            LOG.warning(f'caught a resource not found exception.'
+                        f' sleeping {CONSISTENCY_SLEEP_TIME} seconds and retrying api call for consistency...')
+            time.sleep(CONSISTENCY_SLEEP_TIME)
+            return func(*args, **kwargs)
+    return retry_not_found_exceptions_wrapper
 
 
 def paginated_api_call(item_to_collect, criteria_to_keep=lambda x, y: True, max_pages=MAXIMUM_NUMBER_OF_PAGES):
@@ -171,6 +201,7 @@ def call_create_variable(frauddetector_client,
 # Update APIs
 
 
+@retry_not_found_exceptions
 @api_call_with_debug_logs
 def call_update_variable(frauddetector_client,
                          variable_name: str,
@@ -200,6 +231,7 @@ def call_update_variable(frauddetector_client,
 # Get APIs
 
 
+@retry_not_found_exceptions
 @paginated_api_call(item_to_collect='variables')
 @api_call_with_debug_logs
 def call_get_variables(frauddetector_client, variable_name: str = None):
@@ -216,6 +248,7 @@ def call_get_variables(frauddetector_client, variable_name: str = None):
     return frauddetector_client.get_variables(**args)
 
 
+@retry_not_found_exceptions
 @paginated_api_call(item_to_collect='labels')
 @api_call_with_debug_logs
 def call_get_labels(frauddetector_client, label_name: str = None):
@@ -226,6 +259,7 @@ def call_get_labels(frauddetector_client, label_name: str = None):
     return frauddetector_client.get_labels(**args)
 
 
+@retry_not_found_exceptions
 @paginated_api_call(item_to_collect='entityTypes')
 @api_call_with_debug_logs
 def call_get_entity_types(frauddetector_client, entity_type_name: str = None):
@@ -236,6 +270,7 @@ def call_get_entity_types(frauddetector_client, entity_type_name: str = None):
     return frauddetector_client.get_entity_types(**args)
 
 
+@retry_not_found_exceptions
 @paginated_api_call(item_to_collect='eventTypes')
 @api_call_with_debug_logs
 def call_get_event_types(frauddetector_client, event_type_name: str = None):
@@ -272,6 +307,7 @@ def call_delete_label(frauddetector_client, label_name: str):
 # Tagging
 
 
+@retry_not_found_exceptions
 @paginated_api_call(item_to_collect='tags')
 @api_call_with_debug_logs
 def call_list_tags_for_resource(frauddetector_client, resource_arn: str):
@@ -284,6 +320,7 @@ def call_list_tags_for_resource(frauddetector_client, resource_arn: str):
     return frauddetector_client.list_tags_for_resource(resourceARN=resource_arn)
 
 
+@retry_not_found_exceptions
 @api_call_with_debug_logs
 def call_tag_resource(frauddetector_client, resource_arn: str, tags: List[dict]):
     """
@@ -296,6 +333,7 @@ def call_tag_resource(frauddetector_client, resource_arn: str, tags: List[dict])
     return frauddetector_client.tag_resource(resourceARN=resource_arn, tags=tags)
 
 
+@retry_not_found_exceptions
 @api_call_with_debug_logs
 def call_untag_resource(frauddetector_client, resource_arn: str, tag_keys: List[str]):
     """

--- a/aws-frauddetector-eventtype/src/aws_frauddetector_eventtype/tests/helpers/test_api_helpers.py
+++ b/aws-frauddetector-eventtype/src/aws_frauddetector_eventtype/tests/helpers/test_api_helpers.py
@@ -4,9 +4,71 @@ from ...helpers import (
 )
 from .. import unit_test_utils
 from unittest.mock import MagicMock
+from botocore.exceptions import ClientError
 
 NUMBER_OF_ITEMS_PER_PAGE = 2
 MAX_PAGES = 10
+
+
+def test_retry_not_found_exceptions_decorator_happy_case():
+    mock_afd_client = unit_test_utils.create_mock_afd_client()
+    mock_afd_client.get_labels = MagicMock()
+    mock_afd_client.exceptions.ResourceNotFoundException = ClientError
+    mock_afd_client.get_labels.side_effect = [
+        ClientError({'Code': '', 'Message': ''}, 'get_labels'),
+        {
+            'labels': [{'property': f'{j}'} for j in range(NUMBER_OF_ITEMS_PER_PAGE)]
+        }
+    ]
+
+    @api_helpers.retry_not_found_exceptions
+    def call_get_labels(frauddetector_client):
+        return frauddetector_client.get_labels()
+
+    response = call_get_labels(mock_afd_client)
+    assert len(response['labels']) == NUMBER_OF_ITEMS_PER_PAGE
+    assert mock_afd_client.get_labels.call_count == 2
+
+
+def test_retry_not_found_exceptions_decorator_no_exception():
+    mock_afd_client = unit_test_utils.create_mock_afd_client()
+    mock_afd_client.get_labels = MagicMock(return_value={
+        'labels': [{'property': f'{j}'} for j in range(NUMBER_OF_ITEMS_PER_PAGE)]
+    })
+
+    @api_helpers.retry_not_found_exceptions
+    def call_get_labels(frauddetector_client):
+        return frauddetector_client.get_labels()
+
+    response = call_get_labels(mock_afd_client)
+    assert len(response['labels']) == NUMBER_OF_ITEMS_PER_PAGE
+    assert mock_afd_client.get_labels.call_count == 1
+
+
+def test_retry_not_found_exceptions_decorator_multi_page():
+    mock_afd_client = unit_test_utils.create_mock_afd_client()
+    mock_afd_client.get_labels = MagicMock()
+    mock_afd_client.exceptions.ResourceNotFoundException = ClientError
+    side_effects = [
+        ClientError({'Code': '', 'Message': ''}, 'get_labels')
+    ]
+    side_effects.extend([
+        {
+            'nextToken': 'notNone',
+            'labels': [{'property': f'{i}.{j}'} for j in range(NUMBER_OF_ITEMS_PER_PAGE)]
+        } for i in range(MAX_PAGES + 10)
+    ])
+    mock_afd_client.get_labels.side_effect = side_effects
+
+    @api_helpers.retry_not_found_exceptions
+    @api_helpers.paginated_api_call('labels', max_pages=MAX_PAGES)
+    @api_helpers.api_call_with_debug_logs
+    def call_get_labels(frauddetector_client, nextToken=None):
+        return frauddetector_client.get_labels(nextToken)
+
+    response = call_get_labels(mock_afd_client)
+    assert len(response['labels']) == NUMBER_OF_ITEMS_PER_PAGE * MAX_PAGES
+    assert mock_afd_client.get_labels.call_count == MAX_PAGES + 1
 
 
 def test_paginated_api_call_not_infinite_loop():

--- a/aws-frauddetector-eventtype/src/aws_frauddetector_eventtype/tests/helpers/test_validation_helpers.py
+++ b/aws-frauddetector-eventtype/src/aws_frauddetector_eventtype/tests/helpers/test_validation_helpers.py
@@ -9,7 +9,9 @@ def test_check_if_get_labels_succeeds_client_error_returns_false():
     mock_afd_client = unit_test_utils.create_mock_afd_client()
     mock_afd_client.get_labels = MagicMock()
     mock_afd_client.exceptions.ResourceNotFoundException = ClientError
-    mock_afd_client.get_labels.side_effect = [ClientError({'Code': '', 'Message': ''}, 'get_labels')]
+    # We retry NotFound (for consistency), so return not found twice
+    mock_afd_client.get_labels.side_effect = [ClientError({'Code': '', 'Message': ''}, 'get_labels'),
+                                              ClientError({'Code': '', 'Message': ''}, 'get_labels')]
 
     # Act
     result = validation_helpers.check_if_get_labels_succeeds(mock_afd_client, unit_test_utils.FAKE_NAME)
@@ -41,7 +43,9 @@ def test_check_if_get_entity_types_succeeds_client_error_returns_false():
     mock_afd_client = unit_test_utils.create_mock_afd_client()
     mock_afd_client.get_entity_types = MagicMock()
     mock_afd_client.exceptions.ResourceNotFoundException = ClientError
-    mock_afd_client.get_entity_types.side_effect = [ClientError({'Code': '', 'Message': ''}, 'get_entity_types')]
+    # We retry NotFound (for consistency), so return not found twice
+    mock_afd_client.get_entity_types.side_effect = [ClientError({'Code': '', 'Message': ''}, 'get_entity_types'),
+                                                    ClientError({'Code': '', 'Message': ''}, 'get_entity_types')]
 
     # Act
     result = validation_helpers.check_if_get_entity_types_succeeds(mock_afd_client, unit_test_utils.FAKE_NAME)
@@ -73,7 +77,9 @@ def test_check_if_get_variables_succeeds_client_error_returns_false():
     mock_afd_client = unit_test_utils.create_mock_afd_client()
     mock_afd_client.get_variables = MagicMock()
     mock_afd_client.exceptions.ResourceNotFoundException = ClientError
-    mock_afd_client.get_variables.side_effect = [ClientError({'Code': '', 'Message': ''}, 'get_variables')]
+    # We retry NotFound (for consistency), so return not found twice
+    mock_afd_client.get_variables.side_effect = [ClientError({'Code': '', 'Message': ''}, 'get_variables'),
+                                                 ClientError({'Code': '', 'Message': ''}, 'get_variables')]
 
     # Act
     result = validation_helpers.check_if_get_variables_succeeds(mock_afd_client, unit_test_utils.FAKE_NAME)
@@ -105,7 +111,9 @@ def test_check_if_get_event_types_succeeds_client_error_returns_false():
     mock_afd_client = unit_test_utils.create_mock_afd_client()
     mock_afd_client.get_event_types = MagicMock()
     mock_afd_client.exceptions.ResourceNotFoundException = ClientError
-    mock_afd_client.get_event_types.side_effect = [ClientError({'Code': '', 'Message': ''}, 'get_event_types')]
+    # We retry NotFound (for consistency), so return not found twice
+    mock_afd_client.get_event_types.side_effect = [ClientError({'Code': '', 'Message': ''}, 'get_event_types'),
+                                                   ClientError({'Code': '', 'Message': ''}, 'get_event_types')]
 
     # Act
     result = validation_helpers.check_if_get_event_types_succeeds(mock_afd_client, unit_test_utils.FAKE_NAME)

--- a/aws-frauddetector-label/src/aws_frauddetector_label/helpers/api_helpers.py
+++ b/aws-frauddetector-label/src/aws_frauddetector_label/helpers/api_helpers.py
@@ -3,6 +3,7 @@ from . import validation_helpers
 
 import functools
 import logging
+import time
 
 # Use this logger to forward log messages to CloudWatch Logs.
 LOG = logging.getLogger(__name__)
@@ -11,6 +12,9 @@ LOG.setLevel(logging.DEBUG)
 # Maximum number of pages to get for paginated calls
 # for page size of 100, 100 pages is 10,000 resources, which is twice the largest default service limit
 MAXIMUM_NUMBER_OF_PAGES = 100
+
+# Number of seconds to wait for eventually consistency for `retry_not_found_exceptions` decorator
+CONSISTENCY_SLEEP_TIME = 1.0
 
 
 # Wrapper/decorator
@@ -27,6 +31,32 @@ def api_call_with_debug_logs(func):
         LOG.debug(f'Finished function {func.__name__!r}, returning {value}')
         return value
     return log_wrapper
+
+
+def retry_not_found_exceptions(func):
+    """
+    Retries boto3 not found exception for the decorated function.
+    """
+    @functools.wraps(func)
+    def retry_not_found_exceptions_wrapper(*args, **kwargs):
+        afd_client = kwargs.get('frauddetector_client', None)
+        if not afd_client:
+            if len(args) > 0:
+                afd_client = args[0]
+            else:
+                # We can't grab afd_client, so we can't compare to AFD's RNF Exception.
+                # Just run the function, rather than throwing an error
+                LOG.error('retry_not_found_exceptions_wrapper could not find the afd client! '
+                          'Perhaps the decorator was added to a method that is not supported?')
+                return func(*args, **kwargs)
+        try:
+            return func(*args, **kwargs)
+        except afd_client.exceptions.ResourceNotFoundException:
+            LOG.warning(f'caught a resource not found exception.'
+                        f' sleeping {CONSISTENCY_SLEEP_TIME} seconds and retrying api call for consistency...')
+            time.sleep(CONSISTENCY_SLEEP_TIME)
+            return func(*args, **kwargs)
+    return retry_not_found_exceptions_wrapper
 
 
 def paginated_api_call(item_to_collect, criteria_to_keep=lambda x, y: True, max_pages=MAXIMUM_NUMBER_OF_PAGES):
@@ -237,6 +267,7 @@ def call_batch_create_variable(frauddetector_client,
 # Update APIs
 
 
+@retry_not_found_exceptions
 @api_call_with_debug_logs
 def call_update_variable(frauddetector_client,
                          variable_name: str,
@@ -263,6 +294,7 @@ def call_update_variable(frauddetector_client,
 # Get APIs
 
 
+@retry_not_found_exceptions
 @paginated_api_call(item_to_collect='outcomes')
 @api_call_with_debug_logs
 def call_get_outcomes(frauddetector_client, outcome_name: str = None):
@@ -279,6 +311,7 @@ def call_get_outcomes(frauddetector_client, outcome_name: str = None):
     return frauddetector_client.get_outcomes(**args)
 
 
+@retry_not_found_exceptions
 @paginated_api_call(item_to_collect='variables')
 @api_call_with_debug_logs
 def call_get_variables(frauddetector_client, variable_name: str = None):
@@ -295,6 +328,7 @@ def call_get_variables(frauddetector_client, variable_name: str = None):
     return frauddetector_client.get_variables(**args)
 
 
+@retry_not_found_exceptions
 @paginated_api_call(item_to_collect='detectors')
 @api_call_with_debug_logs
 def call_get_detectors(frauddetector_client, detector_id: str = None):
@@ -305,6 +339,7 @@ def call_get_detectors(frauddetector_client, detector_id: str = None):
     return frauddetector_client.get_detectors(**args)
 
 
+@retry_not_found_exceptions
 @paginated_api_call(item_to_collect='labels')
 @api_call_with_debug_logs
 def call_get_labels(frauddetector_client, label_name: str = None):
@@ -315,6 +350,7 @@ def call_get_labels(frauddetector_client, label_name: str = None):
     return frauddetector_client.get_labels(**args)
 
 
+@retry_not_found_exceptions
 @paginated_api_call(item_to_collect='entityTypes')
 @api_call_with_debug_logs
 def call_get_entity_types(frauddetector_client, entity_type_name: str = None):
@@ -325,6 +361,7 @@ def call_get_entity_types(frauddetector_client, entity_type_name: str = None):
     return frauddetector_client.get_entity_types(**args)
 
 
+@retry_not_found_exceptions
 @paginated_api_call(item_to_collect='eventTypes')
 @api_call_with_debug_logs
 def call_get_event_types(frauddetector_client, event_type_name: str = None):
@@ -382,6 +419,7 @@ def call_delete_label(frauddetector_client, label_name: str):
 # Tagging
 
 
+@retry_not_found_exceptions
 @paginated_api_call(item_to_collect='tags')
 @api_call_with_debug_logs
 def call_list_tags_for_resource(frauddetector_client, resource_arn: str):
@@ -394,6 +432,7 @@ def call_list_tags_for_resource(frauddetector_client, resource_arn: str):
     return frauddetector_client.list_tags_for_resource(resourceARN=resource_arn)
 
 
+@retry_not_found_exceptions
 @api_call_with_debug_logs
 def call_tag_resource(frauddetector_client, resource_arn: str, tags: List[dict]):
     """
@@ -406,6 +445,7 @@ def call_tag_resource(frauddetector_client, resource_arn: str, tags: List[dict])
     return frauddetector_client.tag_resource(resourceARN=resource_arn, tags=tags)
 
 
+@retry_not_found_exceptions
 @api_call_with_debug_logs
 def call_untag_resource(frauddetector_client, resource_arn: str, tag_keys: List[str]):
     """

--- a/aws-frauddetector-label/src/aws_frauddetector_label/tests/helpers/test_api_helpers.py
+++ b/aws-frauddetector-label/src/aws_frauddetector_label/tests/helpers/test_api_helpers.py
@@ -4,9 +4,71 @@ from ...helpers import (
 )
 from .. import unit_test_utils
 from unittest.mock import MagicMock
+from botocore.exceptions import ClientError
 
 NUMBER_OF_ITEMS_PER_PAGE = 2
 MAX_PAGES = 10
+
+
+def test_retry_not_found_exceptions_decorator_happy_case():
+    mock_afd_client = unit_test_utils.create_mock_afd_client()
+    mock_afd_client.get_labels = MagicMock()
+    mock_afd_client.exceptions.ResourceNotFoundException = ClientError
+    mock_afd_client.get_labels.side_effect = [
+        ClientError({'Code': '', 'Message': ''}, 'get_labels'),
+        {
+            'labels': [{'property': f'{j}'} for j in range(NUMBER_OF_ITEMS_PER_PAGE)]
+        }
+    ]
+
+    @api_helpers.retry_not_found_exceptions
+    def call_get_labels(frauddetector_client):
+        return frauddetector_client.get_labels()
+
+    response = call_get_labels(mock_afd_client)
+    assert len(response['labels']) == NUMBER_OF_ITEMS_PER_PAGE
+    assert mock_afd_client.get_labels.call_count == 2
+
+
+def test_retry_not_found_exceptions_decorator_no_exception():
+    mock_afd_client = unit_test_utils.create_mock_afd_client()
+    mock_afd_client.get_labels = MagicMock(return_value={
+        'labels': [{'property': f'{j}'} for j in range(NUMBER_OF_ITEMS_PER_PAGE)]
+    })
+
+    @api_helpers.retry_not_found_exceptions
+    def call_get_labels(frauddetector_client):
+        return frauddetector_client.get_labels()
+
+    response = call_get_labels(mock_afd_client)
+    assert len(response['labels']) == NUMBER_OF_ITEMS_PER_PAGE
+    assert mock_afd_client.get_labels.call_count == 1
+
+
+def test_retry_not_found_exceptions_decorator_multi_page():
+    mock_afd_client = unit_test_utils.create_mock_afd_client()
+    mock_afd_client.get_labels = MagicMock()
+    mock_afd_client.exceptions.ResourceNotFoundException = ClientError
+    side_effects = [
+        ClientError({'Code': '', 'Message': ''}, 'get_labels')
+    ]
+    side_effects.extend([
+        {
+            'nextToken': 'notNone',
+            'labels': [{'property': f'{i}.{j}'} for j in range(NUMBER_OF_ITEMS_PER_PAGE)]
+        } for i in range(MAX_PAGES + 10)
+    ])
+    mock_afd_client.get_labels.side_effect = side_effects
+
+    @api_helpers.retry_not_found_exceptions
+    @api_helpers.paginated_api_call('labels', max_pages=MAX_PAGES)
+    @api_helpers.api_call_with_debug_logs
+    def call_get_labels(frauddetector_client, nextToken=None):
+        return frauddetector_client.get_labels(nextToken)
+
+    response = call_get_labels(mock_afd_client)
+    assert len(response['labels']) == NUMBER_OF_ITEMS_PER_PAGE * MAX_PAGES
+    assert mock_afd_client.get_labels.call_count == MAX_PAGES + 1
 
 
 def test_paginated_api_call_not_infinite_loop():

--- a/aws-frauddetector-label/src/aws_frauddetector_label/tests/helpers/test_validation_helpers.py
+++ b/aws-frauddetector-label/src/aws_frauddetector_label/tests/helpers/test_validation_helpers.py
@@ -9,7 +9,9 @@ def test_check_if_get_labels_succeeds_client_error_returns_false():
     mock_afd_client = unit_test_utils.create_mock_afd_client()
     mock_afd_client.get_labels = MagicMock()
     mock_afd_client.exceptions.ResourceNotFoundException = ClientError
-    mock_afd_client.get_labels.side_effect = [ClientError({'Code': '', 'Message': ''}, 'get_labels')]
+    # We retry NotFound (for consistency), so return not found twice
+    mock_afd_client.get_labels.side_effect = [ClientError({'Code': '', 'Message': ''}, 'get_labels'),
+                                              ClientError({'Code': '', 'Message': ''}, 'get_labels')]
 
     # Act
     result = validation_helpers.check_if_get_labels_succeeds(mock_afd_client, unit_test_utils.FAKE_NAME)

--- a/aws-frauddetector-outcome/src/aws_frauddetector_outcome/helpers/api_helpers.py
+++ b/aws-frauddetector-outcome/src/aws_frauddetector_outcome/helpers/api_helpers.py
@@ -3,6 +3,7 @@ from . import validation_helpers
 
 import functools
 import logging
+import time
 
 # Use this logger to forward log messages to CloudWatch Logs.
 LOG = logging.getLogger(__name__)
@@ -11,6 +12,9 @@ LOG.setLevel(logging.DEBUG)
 # Maximum number of pages to get for paginated calls
 # for page size of 100, 100 pages is 10,000 resources, which is twice the largest default service limit
 MAXIMUM_NUMBER_OF_PAGES = 100
+
+# Number of seconds to wait for eventually consistency for `retry_not_found_exceptions` decorator
+CONSISTENCY_SLEEP_TIME = 1.0
 
 
 # Wrapper/decorator
@@ -27,6 +31,32 @@ def api_call_with_debug_logs(func):
         LOG.debug(f'Finished function {func.__name__!r}, returning {value}')
         return value
     return log_wrapper
+
+
+def retry_not_found_exceptions(func):
+    """
+    Retries boto3 not found exception for the decorated function.
+    """
+    @functools.wraps(func)
+    def retry_not_found_exceptions_wrapper(*args, **kwargs):
+        afd_client = kwargs.get('frauddetector_client', None)
+        if not afd_client:
+            if len(args) > 0:
+                afd_client = args[0]
+            else:
+                # We can't grab afd_client, so we can't compare to AFD's RNF Exception.
+                # Just run the function, rather than throwing an error
+                LOG.error('retry_not_found_exceptions_wrapper could not find the afd client! '
+                          'Perhaps the decorator was added to a method that is not supported?')
+                return func(*args, **kwargs)
+        try:
+            return func(*args, **kwargs)
+        except afd_client.exceptions.ResourceNotFoundException:
+            LOG.warning(f'caught a resource not found exception.'
+                        f' sleeping {CONSISTENCY_SLEEP_TIME} seconds and retrying api call for consistency...')
+            time.sleep(CONSISTENCY_SLEEP_TIME)
+            return func(*args, **kwargs)
+    return retry_not_found_exceptions_wrapper
 
 
 def paginated_api_call(item_to_collect, criteria_to_keep=lambda x, y: True, max_pages=MAXIMUM_NUMBER_OF_PAGES):
@@ -93,6 +123,7 @@ def call_put_outcome(frauddetector_client,
 # Get APIs
 
 
+@retry_not_found_exceptions
 @paginated_api_call(item_to_collect='outcomes')
 @api_call_with_debug_logs
 def call_get_outcomes(frauddetector_client, outcome_name: str = None):
@@ -126,6 +157,7 @@ def call_delete_outcome(frauddetector_client, outcome_name: str):
 # Tagging
 
 
+@retry_not_found_exceptions
 @paginated_api_call(item_to_collect='tags')
 @api_call_with_debug_logs
 def call_list_tags_for_resource(frauddetector_client, resource_arn: str):
@@ -138,6 +170,7 @@ def call_list_tags_for_resource(frauddetector_client, resource_arn: str):
     return frauddetector_client.list_tags_for_resource(resourceARN=resource_arn)
 
 
+@retry_not_found_exceptions
 @api_call_with_debug_logs
 def call_tag_resource(frauddetector_client, resource_arn: str, tags: List[dict]):
     """
@@ -150,6 +183,7 @@ def call_tag_resource(frauddetector_client, resource_arn: str, tags: List[dict])
     return frauddetector_client.tag_resource(resourceARN=resource_arn, tags=tags)
 
 
+@retry_not_found_exceptions
 @api_call_with_debug_logs
 def call_untag_resource(frauddetector_client, resource_arn: str, tag_keys: List[str]):
     """

--- a/aws-frauddetector-outcome/src/tests/helpers/test_api_helpers.py
+++ b/aws-frauddetector-outcome/src/tests/helpers/test_api_helpers.py
@@ -1,8 +1,71 @@
 from aws_frauddetector_outcome.helpers import api_helpers
+from .. import unit_test_utils
 from unittest.mock import MagicMock
+from botocore.exceptions import ClientError
 
 NUMBER_OF_ITEMS_PER_PAGE = 2
 MAX_PAGES = 10
+
+
+def test_retry_not_found_exceptions_decorator_happy_case():
+    mock_afd_client = unit_test_utils.create_mock_afd_client()
+    mock_afd_client.get_labels = MagicMock()
+    mock_afd_client.exceptions.ResourceNotFoundException = ClientError
+    mock_afd_client.get_labels.side_effect = [
+        ClientError({'Code': '', 'Message': ''}, 'get_labels'),
+        {
+            'labels': [{'property': f'{j}'} for j in range(NUMBER_OF_ITEMS_PER_PAGE)]
+        }
+    ]
+
+    @api_helpers.retry_not_found_exceptions
+    def call_get_labels(frauddetector_client):
+        return frauddetector_client.get_labels()
+
+    response = call_get_labels(mock_afd_client)
+    assert len(response['labels']) == NUMBER_OF_ITEMS_PER_PAGE
+    assert mock_afd_client.get_labels.call_count == 2
+
+
+def test_retry_not_found_exceptions_decorator_no_exception():
+    mock_afd_client = unit_test_utils.create_mock_afd_client()
+    mock_afd_client.get_labels = MagicMock(return_value={
+        'labels': [{'property': f'{j}'} for j in range(NUMBER_OF_ITEMS_PER_PAGE)]
+    })
+
+    @api_helpers.retry_not_found_exceptions
+    def call_get_labels(frauddetector_client):
+        return frauddetector_client.get_labels()
+
+    response = call_get_labels(mock_afd_client)
+    assert len(response['labels']) == NUMBER_OF_ITEMS_PER_PAGE
+    assert mock_afd_client.get_labels.call_count == 1
+
+
+def test_retry_not_found_exceptions_decorator_multi_page():
+    mock_afd_client = unit_test_utils.create_mock_afd_client()
+    mock_afd_client.get_labels = MagicMock()
+    mock_afd_client.exceptions.ResourceNotFoundException = ClientError
+    side_effects = [
+        ClientError({'Code': '', 'Message': ''}, 'get_labels')
+    ]
+    side_effects.extend([
+        {
+            'nextToken': 'notNone',
+            'labels': [{'property': f'{i}.{j}'} for j in range(NUMBER_OF_ITEMS_PER_PAGE)]
+        } for i in range(MAX_PAGES + 10)
+    ])
+    mock_afd_client.get_labels.side_effect = side_effects
+
+    @api_helpers.retry_not_found_exceptions
+    @api_helpers.paginated_api_call('labels', max_pages=MAX_PAGES)
+    @api_helpers.api_call_with_debug_logs
+    def call_get_labels(frauddetector_client, nextToken=None):
+        return frauddetector_client.get_labels(nextToken)
+
+    response = call_get_labels(mock_afd_client)
+    assert len(response['labels']) == NUMBER_OF_ITEMS_PER_PAGE * MAX_PAGES
+    assert mock_afd_client.get_labels.call_count == MAX_PAGES + 1
 
 
 def test_paginated_api_call_not_infinite_loop():

--- a/aws-frauddetector-outcome/src/tests/helpers/test_validation_helpers.py
+++ b/aws-frauddetector-outcome/src/tests/helpers/test_validation_helpers.py
@@ -9,7 +9,9 @@ def test_check_if_get_outcomes_succeeds_client_error_returns_false():
     mock_afd_client = unit_test_utils.create_mock_afd_client()
     mock_afd_client.get_outcomes = MagicMock()
     mock_afd_client.exceptions.ResourceNotFoundException = ClientError
-    mock_afd_client.get_outcomes.side_effect = [ClientError({'Code': '', 'Message': ''}, 'get_outcomes')]
+    # We retry NotFound (for consistency), so return not found twice
+    mock_afd_client.get_outcomes.side_effect = [ClientError({'Code': '', 'Message': ''}, 'get_outcomes'),
+                                                ClientError({'Code': '', 'Message': ''}, 'get_outcomes')]
 
     # Act
     result = validation_helpers.check_if_get_outcomes_succeeds(mock_afd_client, unit_test_utils.FAKE_NAME)

--- a/aws-frauddetector-variable/src/aws_frauddetector_variable/tests/helpers/test_api_helpers.py
+++ b/aws-frauddetector-variable/src/aws_frauddetector_variable/tests/helpers/test_api_helpers.py
@@ -4,9 +4,71 @@ from ...helpers import (
 )
 from .. import unit_test_utils
 from unittest.mock import MagicMock
+from botocore.exceptions import ClientError
 
 NUMBER_OF_ITEMS_PER_PAGE = 2
 MAX_PAGES = 10
+
+
+def test_retry_not_found_exceptions_decorator_happy_case():
+    mock_afd_client = unit_test_utils.create_mock_afd_client()
+    mock_afd_client.get_labels = MagicMock()
+    mock_afd_client.exceptions.ResourceNotFoundException = ClientError
+    mock_afd_client.get_labels.side_effect = [
+        ClientError({'Code': '', 'Message': ''}, 'get_labels'),
+        {
+            'labels': [{'property': f'{j}'} for j in range(NUMBER_OF_ITEMS_PER_PAGE)]
+        }
+    ]
+
+    @api_helpers.retry_not_found_exceptions
+    def call_get_labels(frauddetector_client):
+        return frauddetector_client.get_labels()
+
+    response = call_get_labels(mock_afd_client)
+    assert len(response['labels']) == NUMBER_OF_ITEMS_PER_PAGE
+    assert mock_afd_client.get_labels.call_count == 2
+
+
+def test_retry_not_found_exceptions_decorator_no_exception():
+    mock_afd_client = unit_test_utils.create_mock_afd_client()
+    mock_afd_client.get_labels = MagicMock(return_value={
+        'labels': [{'property': f'{j}'} for j in range(NUMBER_OF_ITEMS_PER_PAGE)]
+    })
+
+    @api_helpers.retry_not_found_exceptions
+    def call_get_labels(frauddetector_client):
+        return frauddetector_client.get_labels()
+
+    response = call_get_labels(mock_afd_client)
+    assert len(response['labels']) == NUMBER_OF_ITEMS_PER_PAGE
+    assert mock_afd_client.get_labels.call_count == 1
+
+
+def test_retry_not_found_exceptions_decorator_multi_page():
+    mock_afd_client = unit_test_utils.create_mock_afd_client()
+    mock_afd_client.get_labels = MagicMock()
+    mock_afd_client.exceptions.ResourceNotFoundException = ClientError
+    side_effects = [
+        ClientError({'Code': '', 'Message': ''}, 'get_labels')
+    ]
+    side_effects.extend([
+        {
+            'nextToken': 'notNone',
+            'labels': [{'property': f'{i}.{j}'} for j in range(NUMBER_OF_ITEMS_PER_PAGE)]
+        } for i in range(MAX_PAGES + 10)
+    ])
+    mock_afd_client.get_labels.side_effect = side_effects
+
+    @api_helpers.retry_not_found_exceptions
+    @api_helpers.paginated_api_call('labels', max_pages=MAX_PAGES)
+    @api_helpers.api_call_with_debug_logs
+    def call_get_labels(frauddetector_client, nextToken=None):
+        return frauddetector_client.get_labels(nextToken)
+
+    response = call_get_labels(mock_afd_client)
+    assert len(response['labels']) == NUMBER_OF_ITEMS_PER_PAGE * MAX_PAGES
+    assert mock_afd_client.get_labels.call_count == MAX_PAGES + 1
 
 
 def test_paginated_api_call_not_infinite_loop():

--- a/aws-frauddetector-variable/src/aws_frauddetector_variable/tests/helpers/test_validation_helpers.py
+++ b/aws-frauddetector-variable/src/aws_frauddetector_variable/tests/helpers/test_validation_helpers.py
@@ -9,7 +9,9 @@ def test_check_if_get_variables_succeeds_client_error_returns_false():
     mock_afd_client = unit_test_utils.create_mock_afd_client()
     mock_afd_client.get_variables = MagicMock()
     mock_afd_client.exceptions.ResourceNotFoundException = ClientError
-    mock_afd_client.get_variables.side_effect = [ClientError({'Code': '', 'Message': ''}, 'get_variables')]
+    # We retry NotFound (for consistency), so return not found twice
+    mock_afd_client.get_variables.side_effect = [ClientError({'Code': '', 'Message': ''}, 'get_variables'),
+                                                 ClientError({'Code': '', 'Message': ''}, 'get_variables')]
 
     # Act
     result = validation_helpers.check_if_get_variables_succeeds(mock_afd_client, unit_test_utils.FAKE_NAME)

--- a/common/tests/helpers/test_api_helpers.py
+++ b/common/tests/helpers/test_api_helpers.py
@@ -4,9 +4,71 @@ from ...helpers import (
 )
 from .. import unit_test_utils
 from unittest.mock import MagicMock
+from botocore.exceptions import ClientError
 
 NUMBER_OF_ITEMS_PER_PAGE = 2
 MAX_PAGES = 10
+
+
+def test_retry_not_found_exceptions_decorator_happy_case():
+    mock_afd_client = unit_test_utils.create_mock_afd_client()
+    mock_afd_client.get_labels = MagicMock()
+    mock_afd_client.exceptions.ResourceNotFoundException = ClientError
+    mock_afd_client.get_labels.side_effect = [
+        ClientError({'Code': '', 'Message': ''}, 'get_labels'),
+        {
+            'labels': [{'property': f'{j}'} for j in range(NUMBER_OF_ITEMS_PER_PAGE)]
+        }
+    ]
+
+    @api_helpers.retry_not_found_exceptions
+    def call_get_labels(frauddetector_client):
+        return frauddetector_client.get_labels()
+
+    response = call_get_labels(mock_afd_client)
+    assert len(response['labels']) == NUMBER_OF_ITEMS_PER_PAGE
+    assert mock_afd_client.get_labels.call_count == 2
+
+
+def test_retry_not_found_exceptions_decorator_no_exception():
+    mock_afd_client = unit_test_utils.create_mock_afd_client()
+    mock_afd_client.get_labels = MagicMock(return_value={
+        'labels': [{'property': f'{j}'} for j in range(NUMBER_OF_ITEMS_PER_PAGE)]
+    })
+
+    @api_helpers.retry_not_found_exceptions
+    def call_get_labels(frauddetector_client):
+        return frauddetector_client.get_labels()
+
+    response = call_get_labels(mock_afd_client)
+    assert len(response['labels']) == NUMBER_OF_ITEMS_PER_PAGE
+    assert mock_afd_client.get_labels.call_count == 1
+
+
+def test_retry_not_found_exceptions_decorator_multi_page():
+    mock_afd_client = unit_test_utils.create_mock_afd_client()
+    mock_afd_client.get_labels = MagicMock()
+    mock_afd_client.exceptions.ResourceNotFoundException = ClientError
+    side_effects = [
+        ClientError({'Code': '', 'Message': ''}, 'get_labels')
+    ]
+    side_effects.extend([
+        {
+            'nextToken': 'notNone',
+            'labels': [{'property': f'{i}.{j}'} for j in range(NUMBER_OF_ITEMS_PER_PAGE)]
+        } for i in range(MAX_PAGES + 10)
+    ])
+    mock_afd_client.get_labels.side_effect = side_effects
+
+    @api_helpers.retry_not_found_exceptions
+    @api_helpers.paginated_api_call('labels', max_pages=MAX_PAGES)
+    @api_helpers.api_call_with_debug_logs
+    def call_get_labels(frauddetector_client, nextToken=None):
+        return frauddetector_client.get_labels(nextToken)
+
+    response = call_get_labels(mock_afd_client)
+    assert len(response['labels']) == NUMBER_OF_ITEMS_PER_PAGE * MAX_PAGES
+    assert mock_afd_client.get_labels.call_count == MAX_PAGES + 1
 
 
 def test_paginated_api_call_not_infinite_loop():

--- a/common/tests/helpers/test_validation_helpers.py
+++ b/common/tests/helpers/test_validation_helpers.py
@@ -9,7 +9,9 @@ def test_check_if_get_outcomes_succeeds_client_error_returns_false():
     mock_afd_client = unit_test_utils.create_mock_afd_client()
     mock_afd_client.get_outcomes = MagicMock()
     mock_afd_client.exceptions.ResourceNotFoundException = ClientError
-    mock_afd_client.get_outcomes.side_effect = [ClientError({'Code': '', 'Message': ''}, 'get_outcomes')]
+    # We retry NotFound (for consistency), so return not found twice
+    mock_afd_client.get_outcomes.side_effect = [ClientError({'Code': '', 'Message': ''}, 'get_outcomes'),
+                                                ClientError({'Code': '', 'Message': ''}, 'get_outcomes')]
 
     # Act
     result = validation_helpers.check_if_get_outcomes_succeeds(mock_afd_client, unit_test_utils.FAKE_NAME)
@@ -41,7 +43,9 @@ def test_check_if_get_entity_types_succeeds_client_error_returns_false():
     mock_afd_client = unit_test_utils.create_mock_afd_client()
     mock_afd_client.get_entity_types = MagicMock()
     mock_afd_client.exceptions.ResourceNotFoundException = ClientError
-    mock_afd_client.get_entity_types.side_effect = [ClientError({'Code': '', 'Message': ''}, 'get_entity_types')]
+    # We retry NotFound (for consistency), so return not found twice
+    mock_afd_client.get_entity_types.side_effect = [ClientError({'Code': '', 'Message': ''}, 'get_entity_types'),
+                                                    ClientError({'Code': '', 'Message': ''}, 'get_entity_types')]
 
     # Act
     result = validation_helpers.check_if_get_entity_types_succeeds(mock_afd_client, unit_test_utils.FAKE_NAME)
@@ -73,7 +77,9 @@ def test_check_if_get_labels_succeeds_client_error_returns_false():
     mock_afd_client = unit_test_utils.create_mock_afd_client()
     mock_afd_client.get_labels = MagicMock()
     mock_afd_client.exceptions.ResourceNotFoundException = ClientError
-    mock_afd_client.get_labels.side_effect = [ClientError({'Code': '', 'Message': ''}, 'get_labels')]
+    # We retry NotFound (for consistency), so return not found twice
+    mock_afd_client.get_labels.side_effect = [ClientError({'Code': '', 'Message': ''}, 'get_labels'),
+                                              ClientError({'Code': '', 'Message': ''}, 'get_labels')]
 
     # Act
     result = validation_helpers.check_if_get_labels_succeeds(mock_afd_client, unit_test_utils.FAKE_NAME)


### PR DESCRIPTION
### Description of changes

This is copypasta from Detector RP updates approved in PR https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-frauddetector/pull/21

There is an open issue to refactor common code, as this copypasta is avoidable.

Also, I made these changes with project wide search+replace with regex, and some whitespace got gobbled up. We should implement a pre-commit hook that fixes all styling/pep8 automatically, so we shouldn't worry about the gobbled whitespace for now. 

### Testing

`./run_unit_tests`

```
=== 197 passed in 36.74s ====
```

also ran pre-commit

```
$ pre-commit run --all-files
Check for case conflicts.................................................Passed
Detect Private Key.......................................................Passed
Fix End of Files.........................................................Passed
Mixed line ending........................................................Passed
Trim Trailing Whitespace.................................................Passed
Pretty format JSON.......................................................Passed
Check for merge conflicts................................................Passed
Check Yaml...............................................................Passed
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
