### PR TITLE
fix model version bug for detector RP

### DIFF
--- a/aws-frauddetector-detector/src/aws_frauddetector_detector/tests/helpers/test_model_helpers.py
+++ b/aws-frauddetector-detector/src/aws_frauddetector_detector/tests/helpers/test_model_helpers.py
@@ -51,6 +51,7 @@ def test_get_model_for_detector():
         ]
     }
     get_detector_version_response = unit_test_utils.FAKE_DETECTOR_VERSION_WITH_EXTERNAL_MODEL_AND_MODEL_VERSION
+    get_model_version_response = unit_test_utils.create_fake_model_version()
     get_rules_response = {"ruleDetails": [unit_test_utils.FAKE_RULE_DETAIL]}
     get_outcomes_response = {"outcomes": [unit_test_utils.FAKE_OUTCOME]}
     get_external_models_response = {"externalModels": [unit_test_utils.FAKE_EXTERNAL_MODEL]}
@@ -74,6 +75,7 @@ def test_get_model_for_detector():
     mock_afd_client.get_rules = MagicMock(return_value=get_rules_response)
     mock_afd_client.get_outcomes = MagicMock(return_value=get_outcomes_response)
     mock_afd_client.get_external_models = MagicMock(return_value=get_external_models_response)
+    mock_afd_client.get_model_version = MagicMock(return_value=get_model_version_response)
 
     fake_detector = unit_test_utils.FAKE_DETECTOR
     fake_model = unit_test_utils.create_fake_model()
@@ -101,6 +103,7 @@ def test_get_model_for_detector():
     assert mock_afd_client.get_rules.call_count == 1
     assert mock_afd_client.get_outcomes.call_count == 1
     assert mock_afd_client.get_external_models.call_count == 1
+    assert mock_afd_client.get_model_version.call_count == 1
     assert model_result == output_model
 
 


### PR DESCRIPTION
### Bug

The response syntax [in the docs](https://docs.aws.amazon.com/frauddetector/latest/api/API_GetDetectorVersion.html) suggests we get `arn` for model versions back from `get_detector_version`. We do not. This adds a get_model_version call to get the arn.

Previous error message:

```
Resource of type 'associatedModel' with identifier '{'modelId': 'reference_model_0_do_not_delete', 'modelType': 'ONLINE_FRAUD_INSIGHTS', 'modelVersionNumber': '1.0'}' was not found.
```

### Testing
./run_unit_tests

```
Required test coverage of 89.0% reached. Total coverage: 89.56%
...
==== 215 passed in 32.55s ====
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
