### PR TITLE
run ./cfn_server and ./cfn_test for all RPs

### DIFF
--- a/aws-frauddetector-detector/docs/README.md
+++ b/aws-frauddetector-detector/docs/README.md
@@ -52,9 +52,9 @@ _Required_: Yes
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>64</code>
+_Maximum Length_: <code>64</code>
 
 _Pattern_: <code>^[0-9a-z_-]+$</code>
 
@@ -100,9 +100,9 @@ _Required_: No
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>128</code>
+_Maximum Length_: <code>128</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/aws-frauddetector-detector/docs/entitytype.md
+++ b/aws-frauddetector-detector/docs/entitytype.md
@@ -65,9 +65,9 @@ _Required_: No
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>256</code>
+_Maximum Length_: <code>256</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/aws-frauddetector-detector/docs/eventtype.md
+++ b/aws-frauddetector-detector/docs/eventtype.md
@@ -44,9 +44,9 @@ _Required_: No
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>64</code>
+_Maximum Length_: <code>64</code>
 
 _Pattern_: <code>^[0-9a-z_-]+$</code>
 
@@ -76,9 +76,9 @@ _Required_: No
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>128</code>
+_Maximum Length_: <code>128</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/aws-frauddetector-detector/docs/eventvariable.md
+++ b/aws-frauddetector-detector/docs/eventvariable.md
@@ -111,9 +111,9 @@ _Required_: No
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>256</code>
+_Maximum Length_: <code>256</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/aws-frauddetector-detector/docs/label.md
+++ b/aws-frauddetector-detector/docs/label.md
@@ -65,9 +65,9 @@ _Required_: No
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>256</code>
+_Maximum Length_: <code>256</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/aws-frauddetector-detector/docs/outcome.md
+++ b/aws-frauddetector-detector/docs/outcome.md
@@ -65,9 +65,9 @@ _Required_: No
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>256</code>
+_Maximum Length_: <code>256</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/aws-frauddetector-detector/docs/rule.md
+++ b/aws-frauddetector-detector/docs/rule.md
@@ -108,9 +108,9 @@ _Required_: No
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>256</code>
+_Maximum Length_: <code>256</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/aws-frauddetector-detector/docs/tag.md
+++ b/aws-frauddetector-detector/docs/tag.md
@@ -28,9 +28,9 @@ _Required_: Yes
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>128</code>
+_Maximum Length_: <code>128</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
@@ -40,6 +40,6 @@ _Required_: Yes
 
 _Type_: String
 
-_Maximum_: <code>256</code>
+_Maximum Length_: <code>256</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)

--- a/aws-frauddetector-detector/resource-role.yaml
+++ b/aws-frauddetector-detector/resource-role.yaml
@@ -15,6 +15,13 @@ Resources:
             Principal:
               Service: resources.cloudformation.amazonaws.com
             Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                aws:SourceAccount:
+                  Ref: AWS::AccountId
+              StringLike:
+                aws:SourceArn:
+                  Fn::Sub: arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:type/resource/AWS-FraudDetector-Detector/*
       Path: "/"
       Policies:
         - PolicyName: ResourceTypePolicy

--- a/aws-frauddetector-detector/src/aws_frauddetector_detector/models.py
+++ b/aws-frauddetector-detector/src/aws_frauddetector_detector/models.py
@@ -1,6 +1,14 @@
 # DO NOT modify this file by hand, changes will be overwritten
-import sys
 from dataclasses import dataclass
+
+from cloudformation_cli_python_lib.interface import (
+    BaseModel,
+    BaseResourceHandlerRequest,
+)
+from cloudformation_cli_python_lib.recast import recast_object
+from cloudformation_cli_python_lib.utils import deserialize_list
+
+import sys
 from inspect import getmembers, isclass
 from typing import (
     AbstractSet,
@@ -13,13 +21,6 @@ from typing import (
     Type,
     TypeVar,
 )
-
-from cloudformation_cli_python_lib.interface import (
-    BaseModel,
-    BaseResourceHandlerRequest,
-)
-from cloudformation_cli_python_lib.recast import recast_object
-from cloudformation_cli_python_lib.utils import deserialize_list
 
 T = TypeVar("T")
 
@@ -35,6 +36,7 @@ class ResourceHandlerRequest(BaseResourceHandlerRequest):
     # pylint: disable=invalid-name
     desiredResourceState: Optional["ResourceModel"]
     previousResourceState: Optional["ResourceModel"]
+    typeConfiguration: Optional["TypeConfigurationModel"]
 
 
 @dataclass
@@ -335,3 +337,19 @@ class Model(BaseModel):
 
 # work around possible type aliasing issues when variable has same name as a model
 _Model = Model
+
+
+@dataclass
+class TypeConfigurationModel(BaseModel):
+    @classmethod
+    def _deserialize(
+        cls: Type["_TypeConfigurationModel"],
+        json_data: Optional[Mapping[str, Any]],
+    ) -> Optional["_TypeConfigurationModel"]:
+        if not json_data:
+            return None
+        return cls()
+
+
+# work around possible type aliasing issues when variable has same name as a model
+_TypeConfigurationModel = TypeConfigurationModel

--- a/aws-frauddetector-entitytype/docs/README.md
+++ b/aws-frauddetector-entitytype/docs/README.md
@@ -40,9 +40,9 @@ _Required_: Yes
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>64</code>
+_Maximum Length_: <code>64</code>
 
 _Pattern_: <code>^[0-9a-z_-]+$</code>
 
@@ -66,9 +66,9 @@ _Required_: No
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>128</code>
+_Maximum Length_: <code>128</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/aws-frauddetector-entitytype/docs/tag.md
+++ b/aws-frauddetector-entitytype/docs/tag.md
@@ -28,9 +28,9 @@ _Required_: Yes
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>128</code>
+_Maximum Length_: <code>128</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
@@ -40,6 +40,6 @@ _Required_: Yes
 
 _Type_: String
 
-_Maximum_: <code>256</code>
+_Maximum Length_: <code>256</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)

--- a/aws-frauddetector-entitytype/resource-role.yaml
+++ b/aws-frauddetector-entitytype/resource-role.yaml
@@ -15,6 +15,13 @@ Resources:
             Principal:
               Service: resources.cloudformation.amazonaws.com
             Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                aws:SourceAccount:
+                  Ref: AWS::AccountId
+              StringLike:
+                aws:SourceArn:
+                  Fn::Sub: arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:type/resource/AWS-FraudDetector-EntityType/*
       Path: "/"
       Policies:
         - PolicyName: ResourceTypePolicy

--- a/aws-frauddetector-entitytype/src/aws_frauddetector_entitytype/models.py
+++ b/aws-frauddetector-entitytype/src/aws_frauddetector_entitytype/models.py
@@ -1,6 +1,14 @@
 # DO NOT modify this file by hand, changes will be overwritten
-import sys
 from dataclasses import dataclass
+
+from cloudformation_cli_python_lib.interface import (
+    BaseModel,
+    BaseResourceHandlerRequest,
+)
+from cloudformation_cli_python_lib.recast import recast_object
+from cloudformation_cli_python_lib.utils import deserialize_list
+
+import sys
 from inspect import getmembers, isclass
 from typing import (
     AbstractSet,
@@ -13,13 +21,6 @@ from typing import (
     Type,
     TypeVar,
 )
-
-from cloudformation_cli_python_lib.interface import (
-    BaseModel,
-    BaseResourceHandlerRequest,
-)
-from cloudformation_cli_python_lib.recast import recast_object
-from cloudformation_cli_python_lib.utils import deserialize_list
 
 T = TypeVar("T")
 
@@ -35,6 +36,7 @@ class ResourceHandlerRequest(BaseResourceHandlerRequest):
     # pylint: disable=invalid-name
     desiredResourceState: Optional["ResourceModel"]
     previousResourceState: Optional["ResourceModel"]
+    typeConfiguration: Optional["TypeConfigurationModel"]
 
 
 @dataclass
@@ -89,3 +91,19 @@ class Tag(BaseModel):
 
 # work around possible type aliasing issues when variable has same name as a model
 _Tag = Tag
+
+
+@dataclass
+class TypeConfigurationModel(BaseModel):
+    @classmethod
+    def _deserialize(
+        cls: Type["_TypeConfigurationModel"],
+        json_data: Optional[Mapping[str, Any]],
+    ) -> Optional["_TypeConfigurationModel"]:
+        if not json_data:
+            return None
+        return cls()
+
+
+# work around possible type aliasing issues when variable has same name as a model
+_TypeConfigurationModel = TypeConfigurationModel

--- a/aws-frauddetector-eventtype/docs/README.md
+++ b/aws-frauddetector-eventtype/docs/README.md
@@ -49,9 +49,9 @@ _Required_: Yes
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>64</code>
+_Maximum Length_: <code>64</code>
 
 _Pattern_: <code>^[0-9a-z_-]+$</code>
 
@@ -75,9 +75,9 @@ _Required_: No
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>128</code>
+_Maximum Length_: <code>128</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/aws-frauddetector-eventtype/docs/entitytype.md
+++ b/aws-frauddetector-eventtype/docs/entitytype.md
@@ -65,9 +65,9 @@ _Required_: No
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>256</code>
+_Maximum Length_: <code>256</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/aws-frauddetector-eventtype/docs/eventvariable.md
+++ b/aws-frauddetector-eventtype/docs/eventvariable.md
@@ -111,9 +111,9 @@ _Required_: No
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>256</code>
+_Maximum Length_: <code>256</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/aws-frauddetector-eventtype/docs/label.md
+++ b/aws-frauddetector-eventtype/docs/label.md
@@ -65,9 +65,9 @@ _Required_: No
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>256</code>
+_Maximum Length_: <code>256</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/aws-frauddetector-eventtype/docs/tag.md
+++ b/aws-frauddetector-eventtype/docs/tag.md
@@ -28,9 +28,9 @@ _Required_: Yes
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>128</code>
+_Maximum Length_: <code>128</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
@@ -40,6 +40,6 @@ _Required_: Yes
 
 _Type_: String
 
-_Maximum_: <code>256</code>
+_Maximum Length_: <code>256</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)

--- a/aws-frauddetector-eventtype/resource-role.yaml
+++ b/aws-frauddetector-eventtype/resource-role.yaml
@@ -15,6 +15,13 @@ Resources:
             Principal:
               Service: resources.cloudformation.amazonaws.com
             Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                aws:SourceAccount:
+                  Ref: AWS::AccountId
+              StringLike:
+                aws:SourceArn:
+                  Fn::Sub: arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:type/resource/AWS-FraudDetector-EventType/*
       Path: "/"
       Policies:
         - PolicyName: ResourceTypePolicy

--- a/aws-frauddetector-eventtype/src/aws_frauddetector_eventtype/models.py
+++ b/aws-frauddetector-eventtype/src/aws_frauddetector_eventtype/models.py
@@ -1,6 +1,14 @@
 # DO NOT modify this file by hand, changes will be overwritten
-import sys
 from dataclasses import dataclass
+
+from cloudformation_cli_python_lib.interface import (
+    BaseModel,
+    BaseResourceHandlerRequest,
+)
+from cloudformation_cli_python_lib.recast import recast_object
+from cloudformation_cli_python_lib.utils import deserialize_list
+
+import sys
 from inspect import getmembers, isclass
 from typing import (
     AbstractSet,
@@ -13,13 +21,6 @@ from typing import (
     Type,
     TypeVar,
 )
-
-from cloudformation_cli_python_lib.interface import (
-    BaseModel,
-    BaseResourceHandlerRequest,
-)
-from cloudformation_cli_python_lib.recast import recast_object
-from cloudformation_cli_python_lib.utils import deserialize_list
 
 T = TypeVar("T")
 
@@ -35,6 +36,7 @@ class ResourceHandlerRequest(BaseResourceHandlerRequest):
     # pylint: disable=invalid-name
     desiredResourceState: Optional["ResourceModel"]
     previousResourceState: Optional["ResourceModel"]
+    typeConfiguration: Optional["TypeConfigurationModel"]
 
 
 @dataclass
@@ -199,3 +201,19 @@ class EntityType(BaseModel):
 
 # work around possible type aliasing issues when variable has same name as a model
 _EntityType = EntityType
+
+
+@dataclass
+class TypeConfigurationModel(BaseModel):
+    @classmethod
+    def _deserialize(
+        cls: Type["_TypeConfigurationModel"],
+        json_data: Optional[Mapping[str, Any]],
+    ) -> Optional["_TypeConfigurationModel"]:
+        if not json_data:
+            return None
+        return cls()
+
+
+# work around possible type aliasing issues when variable has same name as a model
+_TypeConfigurationModel = TypeConfigurationModel

--- a/aws-frauddetector-label/docs/README.md
+++ b/aws-frauddetector-label/docs/README.md
@@ -40,9 +40,9 @@ _Required_: Yes
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>64</code>
+_Maximum Length_: <code>64</code>
 
 _Pattern_: <code>^[0-9a-z_-]+$</code>
 
@@ -66,9 +66,9 @@ _Required_: No
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>128</code>
+_Maximum Length_: <code>128</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/aws-frauddetector-label/docs/tag.md
+++ b/aws-frauddetector-label/docs/tag.md
@@ -28,9 +28,9 @@ _Required_: Yes
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>128</code>
+_Maximum Length_: <code>128</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
@@ -40,6 +40,6 @@ _Required_: Yes
 
 _Type_: String
 
-_Maximum_: <code>256</code>
+_Maximum Length_: <code>256</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)

--- a/aws-frauddetector-label/resource-role.yaml
+++ b/aws-frauddetector-label/resource-role.yaml
@@ -15,6 +15,13 @@ Resources:
             Principal:
               Service: resources.cloudformation.amazonaws.com
             Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                aws:SourceAccount:
+                  Ref: AWS::AccountId
+              StringLike:
+                aws:SourceArn:
+                  Fn::Sub: arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:type/resource/AWS-FraudDetector-Label/*
       Path: "/"
       Policies:
         - PolicyName: ResourceTypePolicy

--- a/aws-frauddetector-label/src/aws_frauddetector_label/models.py
+++ b/aws-frauddetector-label/src/aws_frauddetector_label/models.py
@@ -1,6 +1,14 @@
 # DO NOT modify this file by hand, changes will be overwritten
-import sys
 from dataclasses import dataclass
+
+from cloudformation_cli_python_lib.interface import (
+    BaseModel,
+    BaseResourceHandlerRequest,
+)
+from cloudformation_cli_python_lib.recast import recast_object
+from cloudformation_cli_python_lib.utils import deserialize_list
+
+import sys
 from inspect import getmembers, isclass
 from typing import (
     AbstractSet,
@@ -13,13 +21,6 @@ from typing import (
     Type,
     TypeVar,
 )
-
-from cloudformation_cli_python_lib.interface import (
-    BaseModel,
-    BaseResourceHandlerRequest,
-)
-from cloudformation_cli_python_lib.recast import recast_object
-from cloudformation_cli_python_lib.utils import deserialize_list
 
 T = TypeVar("T")
 
@@ -35,6 +36,7 @@ class ResourceHandlerRequest(BaseResourceHandlerRequest):
     # pylint: disable=invalid-name
     desiredResourceState: Optional["ResourceModel"]
     previousResourceState: Optional["ResourceModel"]
+    typeConfiguration: Optional["TypeConfigurationModel"]
 
 
 @dataclass
@@ -89,3 +91,19 @@ class Tag(BaseModel):
 
 # work around possible type aliasing issues when variable has same name as a model
 _Tag = Tag
+
+
+@dataclass
+class TypeConfigurationModel(BaseModel):
+    @classmethod
+    def _deserialize(
+        cls: Type["_TypeConfigurationModel"],
+        json_data: Optional[Mapping[str, Any]],
+    ) -> Optional["_TypeConfigurationModel"]:
+        if not json_data:
+            return None
+        return cls()
+
+
+# work around possible type aliasing issues when variable has same name as a model
+_TypeConfigurationModel = TypeConfigurationModel

--- a/aws-frauddetector-outcome/docs/README.md
+++ b/aws-frauddetector-outcome/docs/README.md
@@ -40,9 +40,9 @@ _Required_: Yes
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>64</code>
+_Maximum Length_: <code>64</code>
 
 _Pattern_: <code>^[0-9a-z_-]+$</code>
 
@@ -66,9 +66,9 @@ _Required_: No
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>128</code>
+_Maximum Length_: <code>128</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/aws-frauddetector-outcome/docs/tag.md
+++ b/aws-frauddetector-outcome/docs/tag.md
@@ -28,9 +28,9 @@ _Required_: Yes
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>128</code>
+_Maximum Length_: <code>128</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
@@ -40,6 +40,6 @@ _Required_: Yes
 
 _Type_: String
 
-_Maximum_: <code>256</code>
+_Maximum Length_: <code>256</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)

--- a/aws-frauddetector-outcome/resource-role.yaml
+++ b/aws-frauddetector-outcome/resource-role.yaml
@@ -15,6 +15,13 @@ Resources:
             Principal:
               Service: resources.cloudformation.amazonaws.com
             Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                aws:SourceAccount:
+                  Ref: AWS::AccountId
+              StringLike:
+                aws:SourceArn:
+                  Fn::Sub: arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:type/resource/AWS-FraudDetector-Outcome/*
       Path: "/"
       Policies:
         - PolicyName: ResourceTypePolicy

--- a/aws-frauddetector-outcome/src/aws_frauddetector_outcome/models.py
+++ b/aws-frauddetector-outcome/src/aws_frauddetector_outcome/models.py
@@ -1,6 +1,14 @@
 # DO NOT modify this file by hand, changes will be overwritten
-import sys
 from dataclasses import dataclass
+
+from cloudformation_cli_python_lib.interface import (
+    BaseModel,
+    BaseResourceHandlerRequest,
+)
+from cloudformation_cli_python_lib.recast import recast_object
+from cloudformation_cli_python_lib.utils import deserialize_list
+
+import sys
 from inspect import getmembers, isclass
 from typing import (
     AbstractSet,
@@ -13,13 +21,6 @@ from typing import (
     Type,
     TypeVar,
 )
-
-from cloudformation_cli_python_lib.interface import (
-    BaseModel,
-    BaseResourceHandlerRequest,
-)
-from cloudformation_cli_python_lib.recast import recast_object
-from cloudformation_cli_python_lib.utils import deserialize_list
 
 T = TypeVar("T")
 
@@ -35,6 +36,7 @@ class ResourceHandlerRequest(BaseResourceHandlerRequest):
     # pylint: disable=invalid-name
     desiredResourceState: Optional["ResourceModel"]
     previousResourceState: Optional["ResourceModel"]
+    typeConfiguration: Optional["TypeConfigurationModel"]
 
 
 @dataclass
@@ -89,3 +91,19 @@ class Tag(BaseModel):
 
 # work around possible type aliasing issues when variable has same name as a model
 _Tag = Tag
+
+
+@dataclass
+class TypeConfigurationModel(BaseModel):
+    @classmethod
+    def _deserialize(
+        cls: Type["_TypeConfigurationModel"],
+        json_data: Optional[Mapping[str, Any]],
+    ) -> Optional["_TypeConfigurationModel"]:
+        if not json_data:
+            return None
+        return cls()
+
+
+# work around possible type aliasing issues when variable has same name as a model
+_TypeConfigurationModel = TypeConfigurationModel

--- a/aws-frauddetector-variable/docs/README.md
+++ b/aws-frauddetector-variable/docs/README.md
@@ -94,9 +94,9 @@ _Required_: No
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>256</code>
+_Maximum Length_: <code>256</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/aws-frauddetector-variable/docs/tag.md
+++ b/aws-frauddetector-variable/docs/tag.md
@@ -28,9 +28,9 @@ _Required_: Yes
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>128</code>
+_Maximum Length_: <code>128</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
@@ -40,6 +40,6 @@ _Required_: Yes
 
 _Type_: String
 
-_Maximum_: <code>256</code>
+_Maximum Length_: <code>256</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)

--- a/aws-frauddetector-variable/resource-role.yaml
+++ b/aws-frauddetector-variable/resource-role.yaml
@@ -15,6 +15,13 @@ Resources:
             Principal:
               Service: resources.cloudformation.amazonaws.com
             Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                aws:SourceAccount:
+                  Ref: AWS::AccountId
+              StringLike:
+                aws:SourceArn:
+                  Fn::Sub: arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:type/resource/AWS-FraudDetector-Variable/*
       Path: "/"
       Policies:
         - PolicyName: ResourceTypePolicy

--- a/aws-frauddetector-variable/src/aws_frauddetector_variable/models.py
+++ b/aws-frauddetector-variable/src/aws_frauddetector_variable/models.py
@@ -1,6 +1,14 @@
 # DO NOT modify this file by hand, changes will be overwritten
-import sys
 from dataclasses import dataclass
+
+from cloudformation_cli_python_lib.interface import (
+    BaseModel,
+    BaseResourceHandlerRequest,
+)
+from cloudformation_cli_python_lib.recast import recast_object
+from cloudformation_cli_python_lib.utils import deserialize_list
+
+import sys
 from inspect import getmembers, isclass
 from typing import (
     AbstractSet,
@@ -13,13 +21,6 @@ from typing import (
     Type,
     TypeVar,
 )
-
-from cloudformation_cli_python_lib.interface import (
-    BaseModel,
-    BaseResourceHandlerRequest,
-)
-from cloudformation_cli_python_lib.recast import recast_object
-from cloudformation_cli_python_lib.utils import deserialize_list
 
 T = TypeVar("T")
 
@@ -35,6 +36,7 @@ class ResourceHandlerRequest(BaseResourceHandlerRequest):
     # pylint: disable=invalid-name
     desiredResourceState: Optional["ResourceModel"]
     previousResourceState: Optional["ResourceModel"]
+    typeConfiguration: Optional["TypeConfigurationModel"]
 
 
 @dataclass
@@ -97,3 +99,19 @@ class Tag(BaseModel):
 
 # work around possible type aliasing issues when variable has same name as a model
 _Tag = Tag
+
+
+@dataclass
+class TypeConfigurationModel(BaseModel):
+    @classmethod
+    def _deserialize(
+        cls: Type["_TypeConfigurationModel"],
+        json_data: Optional[Mapping[str, Any]],
+    ) -> Optional["_TypeConfigurationModel"]:
+        if not json_data:
+            return None
+        return cls()
+
+
+# work around possible type aliasing issues when variable has same name as a model
+_TypeConfigurationModel = TypeConfigurationModel


### PR DESCRIPTION
### Notes

After updating dependencies (e.g. latest CFN cli pip package), ran `./cfn_server` and `./cfn_test` on all of the resource providers. each one succeeds with no errors or failures.

The changes are a result of running `cfn generate` with the latest library, and running `pre-commit run --all-files` afterwards. There are no other changes in this pull request, all of the changes were generated automatically.

### Testing

e.g. `./cfn_server variable` in one terminal and `./cfn_test variable` in another:

```
...
======== 11 passed, 4 skipped, 9 deselected, 1 warning in 148.02s (0:02:28) ==========
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
