### PR TITLE
Add batch_call_limit and add batch variable API helpers

### DIFF
--- a/aws-frauddetector-eventtype/src/aws_frauddetector_eventtype/helpers/util.py
+++ b/aws-frauddetector-eventtype/src/aws_frauddetector_eventtype/helpers/util.py
@@ -5,3 +5,12 @@ def extract_name_from_arn(resource_arn: str) -> Optional[str]:
     if resource_arn is None:
         return None
     return resource_arn.split("/")[-1]
+
+
+def split_array_into_chunks(arr, chunk_size):
+    """
+    Return a generator of arrays of length chunk_size from source array arr.
+    """
+    for i in range(0, len(arr), chunk_size):
+        yield arr[i : i + chunk_size]
+    return


### PR DESCRIPTION
# Notes

## Commit Message
Add batch_call_limit and add batch variable API helpers

add variable entries check to validation helpers

## Description of Changes

These new helpers will allow event type (Detector will also be updated similarly in a later PR) to use Batch create/get variable APIs to prevent the need for a large number of API calls for event types with lots of event variables.

Also update remove_none_arguments to also remove none in nested argument attributes, and add unit tests.

# Testing

`./run_unit_tests`, `./cfn_server eventtype`, and `./cfn_test eventtype`, all without failure.

I've also added an additional set of contract test inputs that have > 100 event variables, to be added in a separate PR.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
