### PR TITLE
add create_inline_event_variables for eventtype helpers

### DIFF
--- a/aws-frauddetector-eventtype/src/aws_frauddetector_eventtype/tests/helpers/test_common_helpers.py
+++ b/aws-frauddetector-eventtype/src/aws_frauddetector_eventtype/tests/helpers/test_common_helpers.py
@@ -53,7 +53,7 @@ def test_put_event_type_and_return_progress(monkeypatch):
     _act_and_assert_put_event_type_for_given_model(mock_afd_client, input_model, output_model)
 
 
-def test_put_inline_event_variable():
+def test_create_inline_event_variable():
     # Arrange
     mock_afd_client = unit_test_utils.create_mock_afd_client()
     mock_afd_client.create_variable = MagicMock()
@@ -73,6 +73,27 @@ def test_put_inline_event_variable():
         description=fake_event_variable.Description,
         variableType=fake_event_variable.VariableType,
         tags=fake_tags,
+    )
+
+
+def test_create_inline_event_variables():
+    # Arrange
+    mock_afd_client = unit_test_utils.create_mock_afd_client()
+    mock_afd_client.batch_create_variable = MagicMock()
+    fake_input_model = unit_test_utils.create_fake_model()
+    fake_event_variables = fake_input_model.EventVariables
+    # Calling internal (would-be-package-private) method to re-build expected arguments
+    tags, variable_entries = common_helpers._get_tags_and_variable_entries_from_inline_event_variables(
+        fake_event_variables
+    )
+
+    # Act
+    common_helpers.create_inline_event_variables(mock_afd_client, fake_event_variables)
+
+    # Assert
+    mock_afd_client.batch_create_variable.assert_called_once_with(
+        tags=tags,
+        variableEntries=variable_entries,
     )
 
 


### PR DESCRIPTION
# Notes

## Commit Message
add create_inline_event_variables for eventtype helpers

## Description of Changes

These new helpers will allow event type handler to use batch APIs to check and create inline event variables for eventtype create and eventtype update.

# Testing

`./run_unit_tests`, `./cfn_server eventtype`, and `./cfn_test eventtype`, all without failure.

I've also tested against an additional set of contract test inputs that have > 100 event variables, added in [PR 37](https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-frauddetector/pull/37).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
